### PR TITLE
feat: adds publish and emit control

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ const immutable = require('@polyn/immutable')
 // formatters
 const { ConsoleStyles } = require('./src/formatters/ConsoleStyles').factory(blueprint, immutable)
 const { validateFormatter } = require('./src/formatters/validate-formatter').factory(blueprint)
-const { errorFormatter } = require('./src/formatters/error-formatter').factory()
-const { BlockFormatter } = require('./src/formatters/BlockFormatter').factory(ConsoleStyles, errorFormatter)
+const { errorFormatter } = require('./src/formatters/error-formatter').factory(blueprint)
+const { BlockFormatter } = require('./src/formatters/BlockFormatter').factory(ConsoleStyles)
 const { BunyanFormatter } = require('./src/formatters/BunyanFormatter').factory(errorFormatter)
-const { JsonFormatter } = require('./src/formatters/JsonFormatter').factory(errorFormatter)
+const { JsonFormatter } = require('./src/formatters/JsonFormatter').factory(blueprint, errorFormatter)
 const { PassThroughFormatter } = require('./src/formatters/PassThroughFormatter').factory()
-const { StringFormatter } = require('./src/formatters/StringFormatter').factory(errorFormatter)
+const { StringFormatter } = require('./src/formatters/StringFormatter').factory(blueprint, errorFormatter)
 
 const formatters = {
   BlockFormatter,
@@ -42,7 +42,7 @@ const { Logger } = require('./src/Logger').factory(
   immutable,
   events,
   LogMetaFactory,
-  validateWriter
+  validateWriter,
 )
 
 module.exports = { Logger, formatters, writers }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/logger",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An async, event based logger for NodeJS",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/formatters/BlockFormatter.js
+++ b/src/formatters/BlockFormatter.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: 'BlockFormatter',
-  dependencies: ['ConsoleStyles', 'error-formatter'],
-  factory: (ConsoleStyles, errorFormatter) => {
+  dependencies: ['ConsoleStyles'],
+  factory: (ConsoleStyles) => {
     'use strict'
 
     const DELIMITER = '::'
@@ -24,14 +24,15 @@ module.exports = {
       }
     }
 
-    const makeDetails = (log) => {
-      if (!log) {
-        return log
-      }
-
-      const clone = errorFormatter.format(log)
-      return typeof clone !== 'object' ? { message: clone } : clone
-    }
+    const makeDetails = (log) => log
+    // {
+    //   if (!log) {
+    //     return log
+    //   }
+    //
+    //   const clone = errorFormatter.format(log)
+    //   return typeof clone !== 'object' ? { message: clone } : clone
+    // }
 
     function BlockFormatter (options) {
       const { consoleStyles } = new ConsoleStyles(options)

--- a/src/formatters/JsonFormatter.js
+++ b/src/formatters/JsonFormatter.js
@@ -1,8 +1,10 @@
 module.exports = {
   name: 'JsonFormatter',
-  dependencies: ['error-formatter'],
-  factory: (errorFormatter) => {
+  dependencies: ['@polyn/blueprint', 'error-formatter'],
+  factory: (polynBp, errorFormatter) => {
     'use strict'
+
+    const { is } = polynBp
 
     function JsonFormatter () {
       /**
@@ -14,9 +16,19 @@ module.exports = {
           return resolve(JSON.stringify(meta))
         }
 
+        let _log
+
+        if (is.primitive(log)) {
+          _log = { log: log }
+        } else if (Array.isArray(log)) {
+          _log = { log: errorFormatter.format(log) }
+        } else {
+          _log = errorFormatter.format(log)
+        }
+
         return resolve(JSON.stringify({
           ...meta,
-          ...errorFormatter.format(log),
+          ..._log,
         }))
       })
 

--- a/src/formatters/StringFormatter.js
+++ b/src/formatters/StringFormatter.js
@@ -1,9 +1,10 @@
 module.exports = {
   name: 'StringFormatter',
-  dependencies: ['error-formatter'],
-  factory: (errorFormatter) => {
+  dependencies: ['@polyn/blueprint', 'error-formatter'],
+  factory: (polynBp, errorFormatter) => {
     'use strict'
 
+    const { is } = polynBp
     const DELIMITER = '::'
 
     function StringFormatter () {
@@ -12,11 +13,9 @@ module.exports = {
        * @param log the log to format
        */
       const format = (log, meta) => new Promise((resolve) => {
-        let message
+        let message = ''
 
-        if (errorFormatter.isError(log)) {
-          message = `${log.message}::\n    ${log.stack}`
-        } else if (typeof log !== 'object') {
+        if (is.primitive(log)) {
           message = log
         } else if (log) {
           message = JSON.stringify(errorFormatter.format(log))

--- a/src/formatters/error-formatter.js
+++ b/src/formatters/error-formatter.js
@@ -1,46 +1,52 @@
 module.exports = {
   name: 'error-formatter',
-  dependencies: [],
-  factory: () => {
+  dependencies: ['@polyn/blueprint'],
+  factory: (polynBp) => {
     'use strict'
 
+    const { is } = polynBp
     const ERR_EXP = /^err$|error/i
     const isError = (prop) => prop && (prop instanceof Error || (prop.message && prop.stack))
     const isErrorProp = (key, prop) => prop && (prop instanceof Error || (ERR_EXP.test(key) && prop.message && prop.stack))
+    const findErrorProperties = (log) => Object.keys(log).filter((key) => isErrorProp(key, log[key]))
 
-    const shallowClone = (log) => {
-      return Object.keys(log).reduce((clone, key) => {
-        if (isErrorProp(key, log[key])) {
-          clone[key] = cloneError(log[key])
-        } else {
-          clone[key] = log[key]
-        }
+    const shallowClone = (errorProps, log) => Object.keys(log).reduce((clone, key) => {
+      if (errorProps.includes(key)) {
+        clone[key] = cloneError(log[key])
+      } else {
+        clone[key] = log[key]
+      }
 
-        return clone
-      }, {})
+      return clone
+    }, {})
+
+    const cloneError = (err) => Object.keys(err).reduce((clone, key) => {
+      clone[key] = err[key]
+      return clone
+    }, {
+      message: err.message,
+      stack: err.stack,
+    })
+
+    const format = (log) => {
+      if (is.array(log)) {
+        return log.map(format)
+      } else if (is.primitive(log)) {
+        return log
+      } else if (isError(log)) {
+        return cloneError(log)
+      }
+
+      const errorProps = findErrorProperties(log)
+
+      if (errorProps.length) {
+        return shallowClone(errorProps, log)
+      }
+
+      return log
     }
 
-    const cloneError = (err) => {
-      return Object.keys(err).reduce((clone, key) => {
-        clone[key] = err[key]
-        return clone
-      }, {
-        message: err.message,
-        stack: err.stack,
-      })
-    }
-
-    const errorFormatter = {
-      format: (log) => {
-        if (isError(log)) {
-          return cloneError(log)
-        }
-
-        return shallowClone(log)
-      },
-      isError,
-      isErrorProp,
-    }
+    const errorFormatter = { format, isError, isErrorProp }
 
     return { errorFormatter }
   },


### PR DESCRIPTION
You can now set each logger instance to use publish (send-and-wait), or
emit (send-and-move-on) modes. You can also control this behavior by
using `log.publish`, and `log.emit` now.

Also fixes some formatting bugs, and adds more documentation.