### PR TITLE
feat: adds new LogEmitter

### DIFF
--- a/README.0.2.2.md
+++ b/README.0.2.2.md
@@ -1,0 +1,410 @@
+## Creating an instance of a logger
+
+We need to do 2 things when creating an instance of a logger: Create a log topic, and then subscribe to that topic, with a log writer.
+
+### Creating a log topic
+
+While it's not necessary to create a topic per domain, it's possible to do that. The examples here assume we need only one topic, and that we'll deal with differences in the domains, by subscribing to the topic with different writers.
+
+When creating an instance of Logger, the following properties are supported:
+
+* **name** {string?}: The name of this logger; it's topic; the name of your app, or library (default is "logger")
+* **events** {string[]?}: The events this logger supports (default is: `^(trace|debug|info|warn|error|fatal)$`)
+* **source** {string?}: The source of a given log (default is: 'GLOBAL'). I usually set this using `logger.withSource(__filename)` (per file).
+* **hostname** {string?}: The machine name (default is `os.hostname()` in NodeJS)
+* **pid** {number?}: The process id (default is `process.pid()` in NodeJS)
+* **defaultMode** {`/^(publish|emit)$/`}: whether the logger should "publish" (send-and-wait; default), or "emit" (send-and-move-on) to log subscribers
+
+An instance of Logger returns the following interface:
+
+* **name** {string}: The name of this instance
+* **log** {function}: This is what you execute to emit log events - more on that later
+* **withSource** {`(source: string) => Logger`}: creates a new instance of Logger using the existing configuration, except setting the source, which is emitted as part of the log metadata
+* **subscribe** {`(events: string|string[], receiver: ILogWriter): Promise<ISubscriptionResult|ISubscriptionResult[]>`}: how you subscribe to log events
+* **unsubscribe** {`(id: string): Promise<boolean>`}: how you unsubscribe from log events
+
+```JavaScript
+const { Logger } = require('@polyn/logger')
+
+// the events this instance will support
+const events = [
+  // metrics
+  // (i.e. Prometheus, Application Insights, New Relic, etc.)
+  'count',
+  'latency',
+  'gauge',
+  // audit trail
+  // (i.e. events that should be auditable, such as access to, or modification of PII)
+  'audit:info',
+  'audit:warn',
+  // only acceptable on local dev
+  // (i.e. debug secrets without risking accidental logging in master)
+  'local',
+  // standard logging fare (events)
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal'
+]
+
+// shown with defaults:
+const logger = new Logger({
+  name: 'logger',
+  events,
+  source: 'GLOBAL',
+  hostname: require('os').hostname(),
+  pid: process.pid(),
+  defaultMode: 'publish'
+})
+const { log } = logger.withSource(__filename)
+```
+
+> We are now ready to write logs... but nothing is listening for them, yet!
+
+### Subscribing to a log topic
+
+This library has several log writers built into it, and it's very easy to write your own, but I'll get to that later. First, lets look at an example:
+
+```JavaScript
+const { Logger, formatters, writers } = require('@polyn/logger')
+const { BlockFormatter } = formatters
+const { DevConsoleWriter } = writers
+
+// the events this instance will support
+const events = [
+  'count', 'latency', 'gauge',                        // metrics
+  'audit:info', 'audit:warn',                         // audit
+  'local',                                            // local dev only!
+  'trace', 'debug', 'info', 'warn', 'error', 'fatal'  // standard events
+]
+
+const logger = new Logger({ name: 'my-app', events })
+const { log } = logger.withSource(__filename)
+
+;(async () => {
+  // subscriptions should be awaited (or promised) before we emit logs
+  await logger.subscribe(
+    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
+    new DevConsoleWriter({ formatter: new BlockFormatter() })
+  )
+
+  // nothing is listening for 'count', 'latency', 'gauge', 'audit:info',
+  // 'audit:warn', or 'local' yet
+
+  // we can emit logs using NodeJS' EventEmitter convention
+  await log('trace', { hello: 'trace' })
+  await log('debug', { hello: 'debug' })
+  await log('info', { hello: 'info' })
+  await log('warn', { hello: 'warn' })
+  await log('error', { hello: 'error' })
+  await log('fatal', { hello: 'fatal' })
+
+  // the events that we set on the log options are dynamically
+  // added to the `log` function
+  await log.trace({ hello: 'trace' })
+  await log.debug({ hello: 'debug' })
+  await log.info({ hello: 'info' })
+  await log.warn({ hello: 'warn' })
+  await log.error({ hello: 'error' })
+  await log.fatal({ hello: 'fatal' })
+})()
+```
+
+### Writing logs
+
+As seen in "Subscribing to a log topic", we can write logs in two ways: using NodeJS' EventEmitter convention, or using the dynamically added log functions. If you are using TypeScript, the latter might be useful because you can write your own typings files that enforce log body types for specific events. Otherwise it's developer preference.
+
+@polyn/logger has no opinion on what a log body is. Logs can be strings, numbers, boolean, objects... whatever, as long as the configured writer can deal with it.
+
+```JavaScript
+const { Logger, formatters, writers } = require('@polyn/logger')
+
+// the events this instance will support
+const events = ['foo', 'bar', 'str', 'more']
+
+const logger = new Logger({ name: 'my-app', events })
+const { log } = logger.withSource(__filename)
+
+// await <subscribe to the logs with a writer>
+
+// we can emit logs using NodeJS' EventEmitter convention
+log('foo', { hello: 'foo' })
+log('bar', { hello: 'bar' })
+log('str', 'message here')
+log('more', 'message', 9, true, { details: 42 }) // multiple args are emitted as an array
+
+// the events that we set on the log options are dynamically
+// added to the `log` function
+log.foo({ hello: 'foo' })
+log.bar({ hello: 'bar' })
+log.str('message here')
+log.more('message', 2, false, { details: 42 }) // multiple args are emitted as an array
+```
+
+#### Publishing vs. Emitting
+
+See the [@polyn/async-events](https://github.com/losandes/polyn-async-events#polynasync-events) documentation for [Publishing a topic](https://github.com/losandes/polyn-async-events#publishing-to-a-topic), and [Emitting a topic](https://github.com/losandes/polyn-async-events#emitting-to-a-topic) for more detailed information.
+
+**tl;dr**: By default, this logger "publishes" the logs (send-and-wait), which means that it waits for subscribers to finish their work before moving on. This is optimized for logging to the console. If you are writing to streams, or other systems, you might prefer to emit the logs instead (send-and-move-on). You can set the default behavior to `defaultMode: 'emit'` when creating an instance of `Logger`. Regardless of the mode, you can always control the behavior using the `log.publish`, and `log.emit` functions.
+
+See [Cookbook: Measuring counts, or gauges with logs](#cookbook-measuring-counts-or-gauges-with-logs), or [Cookbook: Measuring duration / latency with logs](#cookbook-measuring-duration--latency-with-logs) for an examples that use both `emit`, and `publish`.
+
+### Available writers, and formatters
+
+This library exports both formatters, and writers, which can be used interchangeably, or as part of your own custom writers, or formatters. That being said, each formatter this library exports is optimized for a specific writer. The examples here illustrate that coupling.
+
+The ArrayWriter is great for testing, and log evaluation. Which formatter you use for that really depends on how you're evaluating your logs.
+
+Formatters:
+
+* **BlockFormatter**
+* **BunyanFormatter**
+* **JsonFormatter**
+* **PassThroughFormatter**
+* **StringFormatter**
+
+Writers:
+
+* **ArrayWriter**
+* **ConsoleWriter**
+* **DevConsoleWriter**
+* **StdoutWriter**
+
+```JavaScript
+new DevConsoleWriter({ formatter: new BlockFormatter() })
+```
+
+![block-formatter-dev-console-writer](screenshots/block-formatter-dev-console-writer.png)
+
+```JavaScript
+new DevConsoleWriter({
+  formatter: new BlockFormatter({
+    useColors: false
+  })
+})
+```
+
+![block-formatter-dev-console-writer-no-colors](screenshots/block-formatter-dev-console-writer-no-colors.png)
+
+```JavaScript
+new ConsoleWriter({ formatter: new PassThroughFormatter() })
+```
+
+![passthrough-formatter-console-writer](screenshots/passthrough-formatter-console-writer.png)
+
+```JavaScript
+new StdoutWriter({ formatter: new StringFormatter() })
+```
+
+![string-formatter-stdout-writer](screenshots/string-formatter-stdout-writer.png)
+
+```JavaScript
+new StdoutWriter({ formatter: new JsonFormatter() })
+```
+
+![json-formatter-stdout-writer](screenshots/json-formatter-stdout-writer.png)
+
+#### The bunyan formatter
+
+The bunyan formatter accepts an `events` argument which you can use to map the events you are logging to bunyan's level system.
+
+```JavaScript
+// given these events
+const events = ['local', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']
+
+// configure the bunyan levels that should be associated with them
+new StdoutWriter({
+  formatter: new BunyanFormatter({
+    local: 10
+    trace: 10
+    debug: 20
+    info: 30
+    warn: 40
+    error: 50
+    fatal: 60
+  })
+})
+```
+
+The bunyan formatter is expected to be used with bunyan CLI: `node test | npx bunyan`.
+
+![bunyan-formatter-stdout-writer](screenshots/bunyan-formatter-stdout-writer.png)
+
+### Cookbook: Roll your own log writer
+
+To subscribe to an instance of Logger, you need to present it with an object that has an asynchronous `write` function, or promise. Once subscribed, the write function will receive log bodies as the first argument, and log metadata as the second argument. Log bodies can be anything. Log metadata has the following properties:
+
+* **topic** {string}: The name of the logger
+* **id** {string}: A random identifier for this log, which can be used when measuring duration, latency, etc.
+* **time** {number}: Milliseconds since epoch that this log was written
+* **event** {string}: The event that was emitted
+* **source** {string}: The source (i.e. `withSource(__filename)`) of the event
+* **hostname** {string}: The machine name
+* **pid** {number}: The process id
+
+```JavaScript
+const { Logger } = require('@polyn/logger')
+
+// the events this instance will support
+const events = ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+const logger = new Logger({ name: 'my-app', events })
+const { log } = logger.withSource(__filename)
+
+;(async () => {
+  await logger.subscribe(events, {
+    write: async (log, meta) => {
+      console.log('CUSTOM:', log, meta)
+    }
+  })
+
+  log('trace', { hello: 'trace' })
+  log.trace({ hello: 'trace' })
+})()
+```
+
+### Cookbook: Measuring counts, or gauges with logs
+
+```JavaScript
+const { Logger, formatters, writers } = require('@polyn/logger')
+const { BlockFormatter } = formatters
+const { DevConsoleWriter } = writers
+
+const countWriter = () => {
+  const counts = {}
+
+  return {
+    getCount: (name) => counts[name],
+    write: async (log, meta) => {
+      counts[log.name] = counts[log.name] || { name: log.name, count: 0 }
+      counts[log.name].count += 1
+    }
+  }
+}
+
+const gaugeWriter = () => {
+  const gauges = {}
+
+  return {
+    getGauge: (name) => { return gauges[name] },
+    write: async (log, meta) => {
+      if (meta.event === 'gauge:increase') {
+        gauges[log.name] = gauges[log.name] || { name: log.name, gauge: 0 }
+        gauges[log.name].gauge += 1
+      } else if (meta.event === 'gauge:decrease') {
+        gauges[log.name] = gauges[log.name] || { name: log.name, gauge: 1 }
+        gauges[log.name].gauge -= 1
+      }
+
+    }
+  }
+}
+
+// the events this instance will support
+const events = [
+  'count',
+  'gauge:increase', 'gauge:decrease',
+  'metrics'
+]
+const logger = new Logger({ name: 'my-app', events })
+const { log } = logger.withSource(__filename)
+
+const counts = countWriter()
+const gauges = gaugeWriter()
+
+;(async () => {
+  await logger.subscribe(['count'], counts)
+  await logger.subscribe(['gauge:increase', 'gauge:decrease'], gauges)
+  await logger.subscribe(
+    ['metrics'],
+    new DevConsoleWriter({ formatter: new BlockFormatter() })
+  )
+
+  // we don't need to wait for counts to be written/updated
+  await log.emit('count', { name: 'foo' })
+  await log.emit('count', { name: 'bar' })
+  await log.emit('count', { name: 'foo' })
+
+  await log.emit('metrics', counts.getCount('foo'))
+  await log.emit('metrics', counts.getCount('bar'))
+
+  // we do need to wait for gauges to be written/updated for them to be accurate
+  await log.publish('gauge:increase', { name: 'foo' })
+  await log.publish('gauge:increase', { name: 'bar' })
+  await log.publish('gauge:increase', { name: 'foo' })
+
+  await log.publish('metrics', gauges.getGauge('foo'))
+  await log.publish('metrics', gauges.getGauge('bar'))
+
+  await log.publish('gauge:decrease', { name: 'foo' })
+
+  await log.publish('metrics', gauges.getGauge('foo'))
+  await log.publish('metrics', gauges.getGauge('bar'))
+})()
+```
+
+
+### Cookbook: Measuring duration / latency with logs
+
+Let's start with an example writer:
+
+```JavaScript
+const latencyWriter = () => {
+  const latencies = {}
+
+  return {
+    write: async (log, meta) => {
+      if (meta.event === 'latency:start') {
+        latencies[meta.id] = { log, meta, start: Date.now() }
+        return latencies[meta.id]
+      } else if (meta.event === 'latency:end') {
+        const found = latencies[log.meta.id]
+        found.end = Date.now()
+        console.log(`LATENCY  (duration: ${found.end - found.start})`, found.log)
+        delete latencies[log.meta.id]
+        return found
+      }
+    }
+  }
+}
+```
+
+This writer expects two events to be emitted: one to start the timer, and another to end it. Alternatively, the log body could be used to indicate start and end with a single event name. Below is an example that shows how to use such a timer:
+
+```JavaScript
+const { Logger, formatters, writers } = require('@polyn/logger')
+const { BlockFormatter } = formatters
+const { DevConsoleWriter } = writers
+
+// const latencyWriter = <latencyTimer here> (example above)
+
+// the events this instance will support
+const events = [
+  'latency:start', 'latency:end',
+  'trace', 'debug', 'info', 'warn', 'error', 'fatal'
+]
+const logger = new Logger({ name: 'my-app', events })
+const { log } = logger.withSource(__filename)
+
+;(async () => {
+  await logger.subscribe(['latency:start', 'latency:end'], latencyWriter())
+  await logger.subscribe(
+    ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
+    new DevConsoleWriter({ formatter: new BlockFormatter() }),
+  )
+
+  await log.publish('trace', { hello: 'trace' })
+  // prints: TRACE::1576081604801::/polyn-logger/test.manual.js
+
+  // we need to wait for latency to be started for this to be accurate
+  const start = await log.publish('latency:start', { hello: 'latency' })
+  // does not print
+
+  setTimeout(async () => {
+    // we don't need to wait for latency end events to publish, though
+    await log.emit('latency:end', start)
+    // prints: LATENCY (duration: 30) { hello: 'latency' }
+  }, 30)
+})()
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 // Definitions by: Andy Wright <https://github.com/losandes>
 // TypeScript Version: 2.1
 
+import * as EventEmitter from 'events'
 import { ISubscriptionResult, IEventOutput } from '@polyn/async-events'
 
 export interface ILogMeta {
@@ -13,6 +14,17 @@ export interface ILogMeta {
   source: string;
   hostname: string;
   pid: number;
+}
+
+export interface ILogEmitterMeta {
+  event: string;
+  category: string;
+  level: number;
+  source: string;
+  time: number;
+  hostname: string;
+  pid: number;
+  context?: any;
 }
 
 export interface ILogFormatter {
@@ -29,6 +41,15 @@ export interface ILoggerOptions {
   source?: string;
   hostname?: string;
   pid?: number;
+}
+
+export interface ILogEmitterOptions {
+  source?: string;
+  hostname?: string;
+  pid?: number;
+  wildcardEvent?: string;
+  noListenersEvent?: string;
+  context?: any;
 }
 
 /**
@@ -107,4 +128,11 @@ declare namespace writers {
     constructor(options: { formatter: ILogFormatter });
     write (log: any, meta: ILogMeta): Promise<void>;
   }
+}
+
+declare class LogEmitter extends EventEmitter {
+  constructor(options: ILogEmitterOptions | any);
+  emit(event: string | symbol, level: string, ...args: any[]): boolean;
+  pipe(meta: ILogEmitterMeta, ...args: any[]): boolean;
+  child(options: ILogEmitterOptions): LogEmitter;
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
+const EventEmitter = require('events')
 const os = require('os')
-const events = require('@polyn/async-events')
+const asyncEvents = require('@polyn/async-events')
 const blueprint = require('@polyn/blueprint')
 const immutable = require('@polyn/immutable')
 
@@ -36,13 +37,19 @@ const writers = {
 }
 
 // logger
-const { LogMetaFactory } = require('./src/LogMetaFactory').factory(blueprint, immutable, os)
-const { Logger } = require('./src/Logger').factory(
+const { LogMetaFactory } = require('./src/LogMetaFactory')({ blueprint, immutable, os })
+const { Logger } = require('./src/Logger')({
   blueprint,
   immutable,
-  events,
+  asyncEvents,
   LogMetaFactory,
   validateWriter,
-)
+})
+const { LogEmitter } = require('./src/LogEmitter')({
+  blueprint,
+  immutable,
+  EventEmitter,
+  LogMetaFactory,
+})
 
-module.exports = { Logger, formatters, writers }
+module.exports = { Logger, formatters, writers, LogEmitter }

--- a/index.test.js
+++ b/index.test.js
@@ -1,28 +1,120 @@
 module.exports = (test, dependencies) => {
   'use strict'
 
-  const {
-    Logger,
-    formatters,
-    writers
-  } = dependencies
-
-  const {
-    BlockFormatter,
-    BunyanFormatter,
-    JsonFormatter,
-    PassThroughFormatter,
-    StringFormatter,
-  } = formatters
-
-  const {
-    ArrayWriter,
-    ConsoleWriter,
-    DevConsoleWriter,
-    StdoutWriter,
-  } = writers
+  const { LogEmitter } = dependencies
 
   return test('given @polyn/logger', {
+    'given LogEmitter': {
+      given: () => new LogEmitter(),
+      'when I emit an event that has a 1:1 subscription': {
+        when: (emitter) => {
+          const eventResults = []
+          const levelResults = []
+          const wildcardResults = []
+          const noSubscriberResults = []
+          emitter.on('foo_bar', (...args) => eventResults.push(args))
+          emitter.on('debug', (...args) => levelResults.push(args))
+          emitter.on('info', (...args) => levelResults.push(args))
+          emitter.on('*', (...args) => wildcardResults.push(args))
+          emitter.emit('foo_bar', 'debug', { two: 'two' })
+          emitter.emit('foo_bar', 'info', { two: 'two' })
+          emitter.on('', (...args) => noSubscriberResults.push(args))
 
+          return { eventResults, levelResults, wildcardResults, noSubscriberResults }
+        },
+        'I should be able to subscribe to the events': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual.noSubscriberResults.length).to.equal(0)
+          expect(actual.eventResults.length).to.equal(2)
+
+          expect(actual.eventResults[0][1]).to.deep.equal({ two: 'two' })
+          expect(actual.eventResults[0][0].event).to.equal('foo_bar')
+          expect(actual.eventResults[0][0].category).to.equal('debug')
+          expect(actual.eventResults[0][0].level).to.equal(20)
+          expect(actual.eventResults[0][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.eventResults[0][0].hostname).to.be.a('string')
+          expect(actual.eventResults[0][0].pid).to.be.a('number')
+          expect(actual.eventResults[0][0].time).to.be.a('number')
+
+          expect(actual.eventResults[1][1]).to.deep.equal({ two: 'two' })
+          expect(actual.eventResults[1][0].event).to.equal('foo_bar')
+          expect(actual.eventResults[1][0].category).to.equal('info')
+          expect(actual.eventResults[1][0].level).to.equal(30)
+          expect(actual.eventResults[1][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.eventResults[1][0].hostname).to.be.a('string')
+          expect(actual.eventResults[1][0].pid).to.be.a('number')
+          expect(actual.eventResults[1][0].time).to.be.a('number')
+        },
+        'I should be able to subscribe to the levels': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual.noSubscriberResults.length).to.equal(0)
+          expect(actual.levelResults.length).to.equal(2)
+
+          expect(actual.levelResults[0][1]).to.deep.equal({ two: 'two' })
+          expect(actual.levelResults[0][0].event).to.equal('foo_bar')
+          expect(actual.levelResults[0][0].category).to.equal('debug')
+          expect(actual.levelResults[0][0].level).to.equal(20)
+          expect(actual.levelResults[0][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.levelResults[0][0].hostname).to.be.a('string')
+          expect(actual.levelResults[0][0].pid).to.be.a('number')
+          expect(actual.levelResults[0][0].time).to.be.a('number')
+
+          expect(actual.levelResults[1][1]).to.deep.equal({ two: 'two' })
+          expect(actual.levelResults[1][0].event).to.equal('foo_bar')
+          expect(actual.levelResults[1][0].category).to.equal('info')
+          expect(actual.levelResults[1][0].level).to.equal(30)
+          expect(actual.levelResults[1][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.levelResults[1][0].hostname).to.be.a('string')
+          expect(actual.levelResults[1][0].pid).to.be.a('number')
+          expect(actual.levelResults[1][0].time).to.be.a('number')
+        },
+        'I should be able to subscribe to everything (wildcard)': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual.noSubscriberResults.length).to.equal(0)
+          expect(actual.wildcardResults.length).to.equal(2)
+
+          expect(actual.wildcardResults[0][1]).to.deep.equal({ two: 'two' })
+          expect(actual.wildcardResults[0][0].event).to.equal('foo_bar')
+          expect(actual.wildcardResults[0][0].category).to.equal('debug')
+          expect(actual.wildcardResults[0][0].level).to.equal(20)
+          expect(actual.wildcardResults[0][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.wildcardResults[0][0].hostname).to.be.a('string')
+          expect(actual.wildcardResults[0][0].pid).to.be.a('number')
+          expect(actual.wildcardResults[0][0].time).to.be.a('number')
+
+          expect(actual.wildcardResults[1][1]).to.deep.equal({ two: 'two' })
+          expect(actual.wildcardResults[1][0].event).to.equal('foo_bar')
+          expect(actual.wildcardResults[1][0].category).to.equal('info')
+          expect(actual.wildcardResults[1][0].level).to.equal(30)
+          expect(actual.wildcardResults[1][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.wildcardResults[1][0].hostname).to.be.a('string')
+          expect(actual.wildcardResults[1][0].pid).to.be.a('number')
+          expect(actual.wildcardResults[1][0].time).to.be.a('number')
+        },
+      },
+      'when I emit an event that has no subscriptions': {
+        when: (emitter) => {
+          const results = []
+          const noSubscriberResults = []
+          emitter.on('no_listeners', (...args) => noSubscriberResults.push(args))
+          emitter.emit('foo_bar', 'debug', { two: 'two' })
+
+          return { results, noSubscriberResults }
+        },
+        'it should behave like a standard EventEmitter': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual.results.length).to.equal(0)
+          expect(actual.noSubscriberResults.length).to.equal(1)
+          expect(actual.noSubscriberResults[0][1]).to.deep.equal({ two: 'two' })
+          expect(actual.noSubscriberResults[0][0].event).to.equal('foo_bar')
+          expect(actual.noSubscriberResults[0][0].category).to.equal('debug')
+          expect(actual.noSubscriberResults[0][0].level).to.equal(20)
+          expect(actual.noSubscriberResults[0][0].source).to.include('polyn-logger/index.test.js')
+          expect(actual.noSubscriberResults[0][0].hostname).to.be.a('string')
+          expect(actual.noSubscriberResults[0][0].pid).to.be.a('number')
+          expect(actual.noSubscriberResults[0][0].time).to.be.a('number')
+        },
+      },
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/logger",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "An async, event based logger for NodeJS",
   "main": "index.js",
   "types": "index.d.ts",
@@ -17,9 +17,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@polyn/async-events": "~0.2.0",
-    "@polyn/blueprint": "~2.5.1",
-    "@polyn/immutable": "~1.0.7"
+    "@polyn/async-events": "~0.3.0",
+    "@polyn/blueprint": "~2.5.4",
+    "@polyn/immutable": "~1.0.10"
   },
   "devDependencies": {
     "@polyn/logger": "file:.",
@@ -32,8 +32,10 @@
     "eslint-plugin-node": "~10.0.0",
     "eslint-plugin-promise": "~4.2.1",
     "eslint-plugin-standard": "~4.0.1",
+    "koa": "~2.12.0",
+    "koa-router": "~8.0.8",
     "pre-push": "~0.1.1",
-    "supposed": "~1.0.7-beta.1",
+    "supposed": "~1.1.0",
     "typescript": "~3.7.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,10 @@ devDependencies:
   eslint-plugin-node: 10.0.0_eslint@6.7.2
   eslint-plugin-promise: 4.2.1
   eslint-plugin-standard: 4.0.1_eslint@6.7.2
+  koa: 2.12.0
+  koa-router: 8.0.8
   pre-push: 0.1.1
-  supposed: 1.0.7-beta.1
+  supposed: 1.1.0
   typescript: 3.7.5
 lockfileVersion: 5.1
 packages:
@@ -53,6 +55,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-odQFl/+B9idbdS0e8IxDl2ia/LP8KZLXhV3BUeI98TrZp0uoIzQPhGd+5EtzHmT0SMOIaPd7jfz6pOHLWTtl7A==
+  /accepts/1.3.7:
+    dependencies:
+      mime-types: 2.1.27
+      negotiator: 0.6.2
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
   /acorn-jsx/5.1.0_acorn@7.1.0:
     dependencies:
       acorn: 7.1.0
@@ -105,6 +116,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  /any-promise/1.3.0:
+    dev: true
+    resolution:
+      integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=
   /argparse/1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -163,6 +178,15 @@ packages:
       safe-json-stringify: 1.2.0
     resolution:
       integrity: sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=
+  /cache-content-type/1.0.1:
+    dependencies:
+      mime-types: 2.1.27
+      ylru: 1.2.1
+    dev: true
+    engines:
+      node: '>= 6.0.0'
+    resolution:
+      integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
   /callsites/3.1.0:
     dev: true
     engines:
@@ -212,6 +236,13 @@ packages:
     dev: true
     resolution:
       integrity: sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
+  /co/4.6.0:
+    dev: true
+    engines:
+      iojs: '>= 1.0.0'
+      node: '>= 0.12.0'
+    resolution:
+      integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
   /color-convert/1.9.3:
     dependencies:
       color-name: 1.1.3
@@ -232,6 +263,29 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+  /content-disposition/0.5.3:
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+  /content-type/1.0.4:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
+  /cookies/0.8.0:
+    dependencies:
+      depd: 2.0.0
+      keygrip: 1.1.0
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
   /cross-spawn/6.0.5:
     dependencies:
       nice-try: 1.0.5
@@ -250,6 +304,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  /debug/3.1.0:
+    dependencies:
+      ms: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   /debug/4.1.1:
     dependencies:
       ms: 2.1.2
@@ -264,6 +324,10 @@ packages:
       node: '>=0.12'
     resolution:
       integrity: sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  /deep-equal/1.0.1:
+    dev: true
+    resolution:
+      integrity: sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
   /deep-is/0.1.3:
     dev: true
     resolution:
@@ -276,6 +340,26 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  /delegates/1.0.0:
+    dev: true
+    resolution:
+      integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+  /depd/1.1.2:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+  /depd/2.0.0:
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+  /destroy/1.0.4:
+    dev: true
+    resolution:
+      integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
   /doctrine/1.5.0:
     dependencies:
       esutils: 2.0.3
@@ -303,6 +387,10 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  /ee-first/1.1.1:
+    dev: true
+    resolution:
+      integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
   /emoji-regex/7.0.3:
     dev: true
     resolution:
@@ -311,6 +399,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+  /encodeurl/1.0.2:
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -345,6 +439,10 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  /escape-html/1.0.3:
+    dev: true
+    resolution:
+      integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
   /escape-string-regexp/1.0.5:
     dev: true
     engines:
@@ -620,6 +718,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+  /fresh/0.5.2:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
   /fs.realpath/1.0.0:
     dev: true
     resolution:
@@ -702,6 +806,27 @@ packages:
     dev: true
     resolution:
       integrity: sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
+  /http-assert/1.4.1:
+    dependencies:
+      deep-equal: 1.0.1
+      http-errors: 1.7.3
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-rdw7q6GTlibqVVbXr0CKelfV5iY8G2HqEUkhSk297BMbSpSL8crXC+9rjKoMcZZEsksX30le6f/4ul4E28gegw==
+  /http-errors/1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
   /iconv-lite/0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -802,6 +927,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+  /is-generator-function/1.0.7:
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==
   /is-glob/4.0.1:
     dependencies:
       is-extglob: 2.1.1
@@ -836,6 +967,10 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+  /isarray/0.0.1:
+    dev: true
+    resolution:
+      integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
   /isarray/1.0.0:
     dev: true
     resolution:
@@ -864,6 +999,76 @@ packages:
     dev: true
     resolution:
       integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+  /keygrip/1.1.0:
+    dependencies:
+      tsscmp: 1.0.6
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  /koa-compose/3.2.1:
+    dependencies:
+      any-promise: 1.3.0
+    dev: true
+    resolution:
+      integrity: sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=
+  /koa-compose/4.1.0:
+    dev: true
+    resolution:
+      integrity: sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
+  /koa-convert/1.2.0:
+    dependencies:
+      co: 4.6.0
+      koa-compose: 3.2.1
+    dev: true
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=
+  /koa-router/8.0.8:
+    dependencies:
+      debug: 4.1.1
+      http-errors: 1.7.3
+      koa-compose: 4.1.0
+      methods: 1.1.2
+      path-to-regexp: 1.8.0
+      urijs: 1.19.2
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    resolution:
+      integrity: sha512-2rNF2cgu/EWi/NV8GlBE5+H/QBoaof83X6Z0dULmalkbt7W610/lyP2EOLVqVrUUFfjsVWL/Ju5TVBcGJDY9XQ==
+  /koa/2.12.0:
+    dependencies:
+      accepts: 1.3.7
+      cache-content-type: 1.0.1
+      content-disposition: 0.5.3
+      content-type: 1.0.4
+      cookies: 0.8.0
+      debug: 3.1.0
+      delegates: 1.0.0
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      fresh: 0.5.2
+      http-assert: 1.4.1
+      http-errors: 1.7.3
+      is-generator-function: 1.0.7
+      koa-compose: 4.1.0
+      koa-convert: 1.2.0
+      on-finished: 2.3.0
+      only: 0.0.2
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      type-is: 1.6.18
+      vary: 1.1.2
+    dev: true
+    engines:
+      node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4
+    resolution:
+      integrity: sha512-WlUBj6PXoVhjI5ljMmlyK+eqkbVFW5XQu8twz6bd4WM2E67IwKgPMu5wIFXGxAsZT7sW5xAB54KhY8WAEkLPug==
   /levn/0.3.0:
     dependencies:
       prelude-ls: 1.1.2
@@ -897,6 +1102,32 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  /media-typer/0.3.0:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+  /methods/1.1.2:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+  /mime-db/1.44.0:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+  /mime-types/2.1.27:
+    dependencies:
+      mime-db: 1.44.0
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   /mimic-fn/2.1.0:
     dev: true
     engines:
@@ -963,6 +1194,12 @@ packages:
     optional: true
     resolution:
       integrity: sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+  /negotiator/0.6.2:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
   /nice-try/1.0.5:
     dev: true
     resolution:
@@ -1008,6 +1245,14 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  /on-finished/2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   /once/1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -1022,6 +1267,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  /only/0.0.2:
+    dev: true
+    resolution:
+      integrity: sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=
   /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
@@ -1079,6 +1328,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+  /parseurl/1.3.3:
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
   /path-exists/3.0.0:
     dev: true
     engines:
@@ -1101,6 +1356,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  /path-to-regexp/1.8.0:
+    dependencies:
+      isarray: 0.0.1
+    dev: true
+    resolution:
+      integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   /path-type/2.0.0:
     dependencies:
       pify: 2.3.0
@@ -1235,6 +1496,10 @@ packages:
       npm: '>=2.0.0'
     resolution:
       integrity: sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  /safe-buffer/5.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
   /safe-json-stringify/1.2.0:
     dev: true
     optional: true
@@ -1254,6 +1519,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+  /setprototypeof/1.1.1:
+    dev: true
+    resolution:
+      integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
   /shebang-command/1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -1315,6 +1584,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+  /statuses/1.5.0:
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
   /string-width/3.1.0:
     dependencies:
       emoji-regex: 7.0.3
@@ -1389,10 +1664,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  /supposed/1.0.7-beta.1:
+  /supposed/1.1.0:
     dev: true
     resolution:
-      integrity: sha512-ibflWakuwFAPxt071Q58TwBZD80n/NgpupWz+qajFhkHTvY8ixcfiH8NvfLVwV7RcQtyfZ0RE9N96PMp5OieeQ==
+      integrity: sha512-OD7T298xs407RiRHX4EITFUSGbSSgUh2VTcz+LAwR22HW6XWdvWRByPXscw0yu4atd66HgjYoxAj9ogPLJjdsA==
   /table/5.4.6:
     dependencies:
       ajv: 6.11.0
@@ -1420,10 +1695,22 @@ packages:
       node: '>=0.6.0'
     resolution:
       integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  /toidentifier/1.0.0:
+    dev: true
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
   /tslib/1.10.0:
     dev: true
     resolution:
       integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+  /tsscmp/1.0.6:
+    dev: true
+    engines:
+      node: '>=0.6.x'
+    resolution:
+      integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
   /type-check/0.3.2:
     dependencies:
       prelude-ls: 1.1.2
@@ -1444,6 +1731,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+  /type-is/1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.27
+    dev: true
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
   /typescript/3.7.5:
     dev: true
     engines:
@@ -1457,6 +1753,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  /urijs/1.19.2:
+    dev: true
+    resolution:
+      integrity: sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
   /v8-compile-cache/2.1.0:
     dev: true
     resolution:
@@ -1468,6 +1768,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  /vary/1.1.2:
+    dev: true
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
   /which/1.3.1:
     dependencies:
       isexe: 2.0.0
@@ -1493,10 +1799,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  /ylru/1.2.1:
+    dev: true
+    engines:
+      node: '>= 4.0.0'
+    resolution:
+      integrity: sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
 specifiers:
-  '@polyn/async-events': ~0.2.0
-  '@polyn/blueprint': ~2.5.1
-  '@polyn/immutable': ~1.0.7
+  '@polyn/async-events': ~0.3.0
+  '@polyn/blueprint': ~2.5.4
+  '@polyn/immutable': ~1.0.10
   '@polyn/logger': 'file:.'
   '@types/node': ~12.12.17
   bunyan: ~1.8.12
@@ -1507,6 +1819,8 @@ specifiers:
   eslint-plugin-node: ~10.0.0
   eslint-plugin-promise: ~4.2.1
   eslint-plugin-standard: ~4.0.1
+  koa: ~2.12.0
+  koa-router: ~8.0.8
   pre-push: ~0.1.1
-  supposed: ~1.0.7-beta.1
+  supposed: ~1.1.0
   typescript: ~3.7.3

--- a/src/LogEmitter.js
+++ b/src/LogEmitter.js
@@ -1,0 +1,79 @@
+/**
+ * @param {@polyn/blueprint} blueprint
+ * @param {@polyn/immutable} immutable
+ * @param {LogMetaFactory} LogMetaFactory
+ * @param {events} EventEmitter
+ */
+function LogEmitterFactory (deps) {
+  'use strict'
+
+  const { optional } = deps.blueprint
+  const { immutable } = deps.immutable
+  const { LogMetaFactory, EventEmitter } = deps
+  const TAB_AT_EXP = /^(\s+)at /
+
+  const LogEmitterOptions = immutable('LogEmitterOptions', {
+    source: 'string?',
+    hostname: 'string?',
+    pid: 'number?',
+    wildcardEvent: optional('string').withDefault('*'),
+    noListenersEvent: optional('string').withDefault('no_listeners'),
+    context: 'object?',
+  })
+
+  class LogEmitter extends EventEmitter {
+    constructor (input) {
+      super(input)
+      this.options = new LogEmitterOptions(input)
+      this.LogMeta = LogMetaFactory({
+        ...{ isValidEvent: () => true },
+        ...this.options,
+      })
+    }
+
+    __emitWith (meta, ...args) {
+      const events = meta.event === meta.category
+        ? [meta.event, this.options.wildcardEvent]
+        : [meta.event, meta.category, this.options.wildcardEvent]
+
+      return events
+        .map((a) => super.emit(a, meta, ...args))
+        .includes(true) ||
+        super.emit(this.options.noListenersEvent, meta, ...args)
+    }
+
+    emit (event, category, ...args) {
+      const meta = new this.LogMeta({
+        event,
+        category,
+        context: this.options.context,
+        source: (() => {
+          const stack = new Error().stack
+          const lines = stack.split('\n')
+
+          for (let i = 1; i < lines.length; i += 1) {
+            if (!lines[i].includes('LogEmitter.js')) {
+              return lines[i].replace(TAB_AT_EXP, '')
+            }
+          }
+        })(),
+      })
+
+      return this.__emitWith(meta, ...args)
+    }
+
+    pipe () {
+      return (meta, ...args) => this.__emitWith(meta, ...args)
+    }
+
+    child (options) {
+      const emitter = new LogEmitter(options)
+      emitter.on(this.options.wildcardEvent, this.pipe())
+      return emitter
+    }
+  }
+
+  return { LogEmitter }
+}
+
+module.exports = LogEmitterFactory

--- a/src/LogMetaFactory.js
+++ b/src/LogMetaFactory.js
@@ -1,40 +1,62 @@
-module.exports = {
-  name: 'LogMetaFactory',
-  dependencies: ['@polyn/blueprint', '@polyn/immutable', 'os'],
-  factory: (polynBp, polynIm, os) => {
-    'use strict'
+/**
+ * @param {@polyn/blueprint} blueprint
+ * @param {@polyn/immutable} immutable
+ * @param {os} os
+ */
+function LogMetaFactory (deps) {
+  'use strict'
 
-    const { optional, required } = polynBp
-    const { immutable } = polynIm
+  const { optional, required } = deps.blueprint
+  const { immutable } = deps.immutable
+  const { os } = deps
+
+  const LogMetaFactory = (options) => {
+    const { events, hostname, pid } = options
+    const EVENT_EXP_STR = Array.isArray(events) ? `^(${events.join('|')})$` : /^[A-Za-z0-9_.]$/
+    const EVENT_EXP = new RegExp(EVENT_EXP_STR)
     const DEFAULT_SOURCE = 'GLOBAL'
-
-    const LogMetaFactory = (options) => {
-      const { events, hostname, pid } = options
-      const EVENT_EXP_STR = `^(${events.join('|')})$`
-      const EVENT_EXP = new RegExp(EVENT_EXP_STR)
-      const HOST_NAME = hostname || (typeof os !== 'undefined' ? os.hostname() : 'local')
-      const PID = pid || (typeof process !== 'undefined' ? process.pid : 0)
-      const isValidEvent = (value) => EVENT_EXP.test(value)
-
-      return immutable('LogMetaFactory', {
-        // /^(trace|debug|info|warn|error|fatal)$/
-        event: required('string').from(({ value }) => {
-          if (typeof value === 'string') {
-            const output = value.trim()
-
-            if (isValidEvent(output)) {
-              return output
-            }
-          }
-
-          throw new Error(`Invalid Event: expected ${value} to match ${EVENT_EXP_STR}`)
-        }),
-        source: optional('string').withDefault(DEFAULT_SOURCE),
-        hostname: optional('string').withDefault(HOST_NAME),
-        pid: optional('number').withDefault(PID),
-      })
+    const HOST_NAME = hostname || (typeof os !== 'undefined' ? os.hostname() : 'local')
+    const PID = pid || (typeof process !== 'undefined' ? process.pid : 0)
+    const isValidEvent = typeof options.isValidEvent === 'function'
+      ? options.isValidEvent
+      : (value) => EVENT_EXP.test(value)
+    const levels = {
+      trace: 10,
+      debug: 20,
+      info: 30,
+      warn: 40,
+      error: 50,
+      fatal: 60,
     }
 
-    return { LogMetaFactory }
-  },
+    return immutable('LogMetaFactory', {
+      event: 'string',
+      // event: /^(trace|debug|info|warn|error|fatal)$/
+      category: required('string').from(({ value, input }) => {
+        const val = value || input.event
+
+        if (typeof val === 'string') {
+          const output = val.trim()
+
+          if (isValidEvent(output)) {
+            return output
+          }
+        }
+
+        throw new Error(`Invalid Event: expected ${value} to match ${EVENT_EXP_STR}`)
+      }),
+      level: required('number').from(({ output }) =>
+        typeof levels[output.category] === 'number' ? levels[output.category] : 10
+      ),
+      source: optional('string').withDefault(DEFAULT_SOURCE),
+      hostname: optional('string').withDefault(HOST_NAME),
+      pid: optional('number').withDefault(PID),
+      time: required('number').from(({ value }) => value || Date.now()),
+      context: 'object?',
+    })
+  }
+
+  return { LogMetaFactory }
 }
+
+module.exports = LogMetaFactory

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,106 +1,114 @@
-module.exports = {
-  name: 'LogMeta',
-  dependencies: ['@polyn/blueprint', '@polyn/immutable', '@polyn/async-events', 'LogMetaFactory', 'validate-writer'],
-  factory: (polynBp, polynIm, polynEv, LogMetaFactory, validateWriter) => {
-    'use strict'
+/**
+ * @param {'@polyn/blueprint'} blueprint
+ * @param {'@polyn/immutable'} immutable
+ * @param {'@polyn/async-events'} asyncEvents
+ * @param {'LogMetaFactory'} LogMetaFactory
+ * @param {'validate-writer'} validateWriter
+ */
+function LoggerFactory (deps) {
+  'use strict'
 
-    const { optional } = polynBp
-    const { immutable } = polynIm
-    const { Topic } = polynEv
+  const { optional } = deps.blueprint
+  const { immutable } = deps.immutable
+  const { Topic } = deps.asyncEvents
+  const { LogMetaFactory, validateWriter } = deps
+  const TAB_AT_EXP = /^(\s+)at /
 
-    const LoggerOptions = immutable('LoggerOptions', {
-      name: optional('string').withDefault('logger'),
-      events: optional('string[]').from(({ value }) => {
-        if (Array.isArray(value)) {
-          const values = value.map((val) => val.trim())
+  const LoggerOptions = immutable('LoggerOptions', {
+    name: optional('string').withDefault('logger'),
+    events: optional('string[]').from(({ value }) => {
+      if (Array.isArray(value)) {
+        const values = value.map((val) => val.trim())
 
-          if (values.includes('publish') || values.includes('emit')) {
-            throw new Error('Invalid Logger Options: the following event names are protected, and cannot be configured: "publish", "emit"')
-          }
-
-          return values
+        if (values.includes('publish') || values.includes('emit')) {
+          throw new Error('Invalid Logger Options: the following event names are reserved, and cannot be configured: "publish", "emit"')
         }
 
-        return ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
-      }),
-      source: 'string?',
-      hostname: 'string?',
-      pid: 'number?',
-      defaultMode: optional(/^(publish|emit)$/).withDefault('publish')
+        return values
+      }
+
+      return ['trace', 'debug', 'info', 'warn', 'error', 'fatal']
+    }),
+    source: 'string?',
+    hostname: 'string?',
+    pid: 'number?',
+    defaultMode: optional(/^(publish|emit)$/).withDefault('publish')
+  })
+
+  /**
+   * @param input - the unsanitized input (so we can use references)
+   */
+  const makeOptions = (input) => {
+    let logTopic, options
+
+    if (input && input.__logTopic) {
+      options = new LoggerOptions(input)
+      logTopic = (input && input.__logTopic)
+    } else {
+      options = new LoggerOptions(input)
+      logTopic = new Topic({ topic: options.name })
+    }
+
+    return { logTopic, options }
+  }
+
+  function Logger (input) {
+    const { logTopic, options } = makeOptions(input)
+    const withSource = (source) => new Logger({
+      ...input,
+      ...{
+        source,
+        __logTopic: logTopic, // always use the same topic, so subscriptions are respected
+      },
+    })
+    const subscribe = (events, writer) => new Promise((resolve, reject) => {
+      try {
+        validateWriter({ writer })
+        const receiver = (body, meta) => writer.write(body, meta)
+
+        return logTopic.subscribe(events, receiver)
+          .then(resolve)
+          .catch(reject)
+      } catch (e) {
+        reject(e)
+      }
+    })
+    const unsubscribe = logTopic.unsubscribe
+    const LogMeta = LogMetaFactory(options)
+
+    const _log = (action) => (event) => {
+      return (...body) => action(
+        event,
+        body && body.length === 1 ? body[0] : body, // support multiple params, but don't muddy up single params
+        new LogMeta({
+          event,
+          source: options.source || (() => {
+            const stack = new Error().stack
+            const lines = stack.split('\n')
+
+            for (let i = 1; i < lines.length; i += 1) {
+              if (!lines[i].includes('Logger.js')) {
+                return lines[i].replace(TAB_AT_EXP, '')
+              }
+            }
+          })(),
+        }),
+      )
+    }
+
+    const log = (event, body) => _log(logTopic[options.defaultMode])(event)(body)
+
+    options.events.forEach((event) => {
+      log[event] = _log(logTopic[options.defaultMode])(event)
     })
 
-    /**
-     * @param input - the unsanitized input (so we can use references)
-     */
-    const makeOptions = (input) => {
-      let logTopic, options
+    log.publish = (event, body) => _log(logTopic.publish)(event)(body)
+    log.emit =    (event, body) => _log(logTopic.emit)(event)(body)
 
-      if (input && input.__logTopic) {
-        options = new LoggerOptions(input)
-        logTopic = (input && input.__logTopic)
-      } else {
-        options = new LoggerOptions(input)
-        logTopic = new Topic({ topic: options.name })
-      }
+    return { name: options.name, withSource, subscribe, unsubscribe, log }
+  }
 
-      return { logTopic, options }
-    }
-
-    function Logger (input) {
-      const { logTopic, options } = makeOptions(input)
-      const withSource = (source) => new Logger({
-        ...input,
-        ...{
-          source,
-          __logTopic: logTopic, // always use the same topic, so subscriptions are respected
-        },
-      })
-      const subscribe = (events, writer) => new Promise((resolve, reject) => {
-        try {
-          validateWriter({ writer })
-          const receiver = (body, meta) => writer.write(body, {
-            topic: meta.topic,
-            id: meta.id,
-            time: meta.time,
-            event: meta.event,
-            source: meta.source,
-            hostname: meta.hostname,
-            pid: meta.pid,
-          })
-
-          return logTopic.subscribe(events, receiver)
-            .then(resolve)
-            .catch(reject)
-        } catch (e) {
-          reject(e)
-        }
-      })
-      const unsubscribe = logTopic.unsubscribe
-      const LogMeta = LogMetaFactory(options)
-
-      const _log = (action) => (event) => {
-        return (...body) => action(
-          event,
-          body && body.length === 1 ? body[0] : body, // support multiple params, but don't muddy up single params
-          new LogMeta({
-            event,
-            source: options.source,
-          }),
-        )
-      }
-
-      const log = (event, body) => _log(logTopic[options.defaultMode])(event)(body)
-
-      options.events.forEach((event) => {
-        log[event] = _log(logTopic[options.defaultMode])(event)
-      })
-
-      log.publish = (event, body) => _log(logTopic.publish)(event)(body)
-      log.emit =    (event, body) => _log(logTopic.emit)(event)(body)
-
-      return { name: options.name, withSource, subscribe, unsubscribe, log }
-    }
-
-    return { Logger }
-  },
+  return { Logger}
 }
+
+module.exports = LoggerFactory

--- a/src/formatters/BlockFormatter.js
+++ b/src/formatters/BlockFormatter.js
@@ -5,22 +5,22 @@ module.exports = {
     'use strict'
 
     const DELIMITER = '::'
-    const prettifyVerbosityFactory = (styles) => (event) => {
-      switch (event) {
+    const prettifyVerbosityFactory = (styles) => (category) => {
+      switch (category) {
         case 'trace':
-          return styles.bgWhite(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgWhite(styles.black(` ${category.toUpperCase()} `))
         case 'debug':
-          return styles.bgGreen(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgGreen(styles.black(` ${category.toUpperCase()} `))
         case 'info':
-          return styles.bgBlue(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgBlue(styles.black(` ${category.toUpperCase()} `))
         case 'warn':
-          return styles.bgYellow(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgYellow(styles.black(` ${category.toUpperCase()} `))
         case 'error':
-          return styles.bgRed(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgRed(styles.black(` ${category.toUpperCase()} `))
         case 'fatal':
-          return styles.bgMagenta(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgMagenta(styles.black(` ${category.toUpperCase()} `))
         default:
-          return styles.bgWhite(styles.black(` ${event.toUpperCase()} `))
+          return styles.bgWhite(styles.black(` ${category.toUpperCase()} `))
       }
     }
 
@@ -43,8 +43,12 @@ module.exports = {
        * @param log the log to format
        */
       const format = (log, meta) => new Promise((resolve) => {
+        const entryParts = meta.category === meta.event
+          ? [prettifyVerbosity(meta.category), meta.time, meta.source]
+          : [prettifyVerbosity(meta.category), meta.event, meta.time, meta.source]
+
         return resolve({
-          entry: [prettifyVerbosity(meta.event), meta.time, meta.source].join(DELIMITER),
+          entry: entryParts.join(DELIMITER),
           details: makeDetails(log),
         })
       })

--- a/src/formatters/BunyanFormatter.js
+++ b/src/formatters/BunyanFormatter.js
@@ -8,38 +8,6 @@ module.exports = {
     'use strict'
 
     function BunyanFormatter (events) {
-      let levels
-
-      if (Array.isArray(events)) {
-        levels = {}
-        let current = 60
-
-        /*
-         * starts at the max level, and works down to 10
-         * ['local2', 'local', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']
-         *   =>
-         * ['trace',  'trace', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']
-         * [10,       10,      10,      20,      30,     40,     50,      60]
-         */
-        for (let i = events.length - 1; i >= 0; i -= 1) {
-          levels[events[i]] = current
-
-          if (current > 10) {
-            current -= 10
-          }
-        }
-      } else if (events) {
-        levels = events
-      } else {
-        levels = {}
-      }
-
-      const getLevel = (event) => {
-        const level = levels[event]
-
-        return typeof level === 'number' ? level : 30
-      }
-
       /**
        * Formats the output
        * @param log the log to format
@@ -47,7 +15,7 @@ module.exports = {
       const format = (log, meta) => new Promise((resolve) => {
         return resolve(JSON.stringify({
           v: 2,
-          level: getLevel(meta.event),
+          level: meta.level,
           name: meta.topic,
           hostname: meta.hostname,
           pid: meta.pid,

--- a/src/formatters/StringFormatter.js
+++ b/src/formatters/StringFormatter.js
@@ -23,12 +23,11 @@ module.exports = {
 
         // remove line breaks
         message = typeof message === 'string' ? message.replace(/\n/g, '\\n').replace(/\r/g, '\\r') : ''
-        return resolve([
-          meta.event.toUpperCase(),
-          meta.time,
-          meta.source,
-          message,
-        ].join(DELIMITER))
+        const parts = meta.category === meta.event
+          ? [meta.category.toUpperCase(), meta.time, meta.source, message]
+          : [meta.category.toUpperCase(), meta.event, meta.time, meta.source, message]
+
+        return resolve(parts.join(DELIMITER))
       })
 
       return { format }

--- a/test.js
+++ b/test.js
@@ -1,12 +1,13 @@
 const { expect } = require('chai')
 const supposed = require('supposed')
-const { Logger, formatters, writers } = require('@polyn/logger')
+const { Logger, LogEmitter, formatters, writers } = require('@polyn/logger')
 
 module.exports = supposed.Suite({
   name: 'polyn-logger',
   assertionLibrary: expect,
   inject: {
     Logger,
+    LogEmitter,
     formatters,
     writers,
   },

--- a/test.manual.js
+++ b/test.manual.js
@@ -1,4 +1,4 @@
-const { Logger, formatters, writers } = require('@polyn/logger')
+const { Logger, LogEmitter, formatters, writers } = require('@polyn/logger')
 const {
   BlockFormatter,
   BunyanFormatter,
@@ -36,7 +36,7 @@ const _writers = [
 ]
 
 // standard fare
-;(async () => {
+const standardFare = async () => {
   try {
     const events = [
       'local',
@@ -83,15 +83,16 @@ const _writers = [
       await log.fatal({ err: new Error('log.fatal!') })
     }
 
+    await writeLogs(logger)
     await writeLogs(logger.withSource('@polyn/logger README 1'))
     await writeLogs(logger.withSource('@polyn/logger README 2'))
   } catch (e) {
     console.log('test.manual', e)
   }
-})()
+}
 
 // multiple parameters, and parameter types
-;(async () => {
+const multipleParams = async () => {
   // the events this instance will support
   const events = ['foo', 'bar', 'str', 'more', 'err']
 
@@ -118,10 +119,10 @@ const _writers = [
 
   test(logger.withSource(__filename))
   test(logger.withSource('two'))
-})()
+}
 
 // publish / emit
-;(async () => {
+const publishAndEmit = async () => {
   try {
     const logger = new Logger({ name: 'publish/emit', events: ['info'] })
     await logger.subscribe(['info'], _writers[0])
@@ -132,10 +133,10 @@ const _writers = [
   } catch (e) {
     console.log('test.manual/publish-emit', e)
   }
-})()
+}
 
-// metrics: counts & gauges
-;(async () => {
+// Logger metrics: counts & gauges
+const countsAndGaugesLogger = async () => {
   const countWriter = () => {
     const counts = {}
 
@@ -205,10 +206,92 @@ const _writers = [
     await log.publish('metrics', gauges.getGauge('foo'))
     await log.publish('metrics', gauges.getGauge('bar'))
   })()
-})()
+}
 
-// metrics: latency
-;(async () => {
+// LogEmitter metrics: counts & gauges
+const countsAndGaugesLogEmitter = async () => {
+  const log = new LogEmitter()
+
+  function CountWriter () {
+    const counts = {}
+
+    return {
+      getCount: (name) => counts[name],
+      write: async (meta, ...args) => {
+        const log = args[0]
+        counts[meta.event] = counts[meta.event] || { name: meta.event, count: 0 }
+        counts[meta.event].count += 1
+      },
+    }
+  }
+
+  function GaugeWriter () {
+    const gauges = {}
+
+    return {
+      getGauge: (name) => { return gauges[name] },
+      write: async (meta, ...args) => {
+        const log = args[0]
+        if (meta.category === 'gauge:increase') {
+          gauges[meta.event] = gauges[meta.event] || { name: meta.event, gauge: 0 }
+          gauges[meta.event].gauge += 1
+        } else if (meta.category === 'gauge:decrease') {
+          gauges[meta.event] = gauges[meta.event] || { name: meta.event, gauge: 1 }
+          gauges[meta.event].gauge -= 1
+        }
+      },
+    }
+  }
+
+  const counts = new CountWriter()
+  const gauges = new GaugeWriter()
+
+  log.on('count', counts.write)
+  log.on('gauge:increase', gauges.write)
+  log.on('gauge:decrease', gauges.write)
+  log.on('metrics', (meta, ...args) =>
+    console.log(meta.event, args[0])
+  )
+
+  const testCountMetrics = (name, expected) => {
+    const actual = counts.getCount(name)
+    return {
+      success: expected === actual.count,
+      expected: expected,
+      actual,
+    }
+  }
+
+  const testGaugeMetrics = (name, expected) => {
+    const actual = gauges.getGauge(name)
+    return {
+      success: expected === actual.gauge,
+      expected: expected,
+      actual,
+    }
+  }
+
+  log.emit('foo', 'count', { labels: { a: 'label' } })
+  log.emit('bar', 'count', { labels: { a: 'label' } })
+  log.emit('foo', 'count', { labels: { a: 'label' } })
+
+  log.emit('foo', 'metrics', testCountMetrics('foo', 2))
+  log.emit('bar', 'metrics', testCountMetrics('bar', 1))
+
+  log.emit('bar', 'gauge:increase', { labels: { a: 'label' } })
+  log.emit('foo', 'gauge:increase', { labels: { a: 'label' } })
+
+  log.emit('foo', 'metrics', testGaugeMetrics('foo', 1))
+  log.emit('bar', 'metrics', testGaugeMetrics('bar', 1))
+
+  log.emit('foo', 'gauge:decrease', { labels: { a: 'label' } })
+
+  log.emit('foo', 'metrics', testGaugeMetrics('foo', 0))
+  log.emit('bar', 'metrics', testGaugeMetrics('bar', 1))
+}
+
+// Logger metrics: latency
+const latencyLogger = async () => {
   const latencyWriter = () => {
     const latencies = {}
 
@@ -256,4 +339,224 @@ const _writers = [
       // prints: LATENCY (duration: 30) { hello: 'latency' }
     }, 30)
   })()
+}
+
+// LogEmitter metrics: latency
+const latencyLogEmitter = async () => {
+  const log = new LogEmitter()
+  const { randomBytes } = require('crypto')
+
+  function LatencyWriter () {
+    const latencies = {}
+
+    return {
+      write: async (meta, ...args) => {
+        const log = args[0]
+        if (meta.category === 'latency:start') {
+          latencies[meta.event] = {
+            log,
+            meta,
+            start: Date.now()
+          }
+        } else if (meta.category === 'latency:end') {
+          const end = Date.now()
+          const found = latencies[meta.event]
+          console.log(`LATENCY  (duration: ${end - found.start})`, found.log)
+          delete latencies[meta.event]
+        }
+      },
+    }
+  }
+
+  const latencyWriter = new LatencyWriter()
+
+  log.on('latency:start', latencyWriter.write)
+  log.on('latency:end', latencyWriter.write)
+
+  const id = randomBytes(4).toString('hex')
+  log.emit(id, 'latency:start', { labels: { a: 'property' } })
+  // does not print
+
+  setTimeout(() => {
+    log.emit(id, 'latency:end')
+    // prints: LATENCY (duration: 30) { hello: 'latency' }
+  }, 30)
+}
+
+// log emitter
+const logEmitter = async () => {
+  const emitter = new LogEmitter()
+  const writer = _writers[0]
+  const writeLog = async (meta, ...args) =>
+    writer.write(args && args.length === 1 ? args[0] : args, meta)
+  const writeLogIf = (matcher) => async (meta, ...args) => {
+    if (matcher(meta, ...args)) {
+      return writeLog(meta, meta, ...args)
+    }
+  }
+  const cleanseAndWrite = async (meta, ...args) => {
+    const body = { ...args[0] }
+    delete body.secret
+    return writeLog(meta, body)
+  }
+
+  ;['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'special']
+    .forEach((level) => emitter.on(level, writeLog))
+  emitter.on('*', writeLogIf((meta) => /^regex_/.test(meta.event)))
+  emitter.on('has_secret', cleanseAndWrite)
+
+  emitter.emit('hello_world', 'debug', { hello: 'emitter.emit("hello_world", "debug")' })
+  emitter.emit('multi-arg', 'debug',
+    { hello: 'emitter.emit("multi-arg", "debug")' },
+    { something: 'else' }
+  )
+  emitter.emit('special', 'local', { hello: 'emitter.emit("special", "local")' })
+  emitter.emit('regex_test', 'local', { hello: 'emitter.emit("regex_test", "local")' })
+  emitter.emit('has_secret', 'local', {
+    hello: 'emitter.emit("has_secret", "local")',
+    secret: 'shhhhh',
+  })
+}
+
+// README - getting started
+const gettingStarted = async () => {
+  const log = new LogEmitter()
+  const logWriter = new writers.DevConsoleWriter({
+    formatter: new formatters.BlockFormatter()
+  })
+  const writeLog = async (meta, ...args) =>
+    logWriter.write(args && args.length === 1 ? args[0] : args, meta)
+
+  // subscribe to a category
+  log.on('info', writeLog)
+
+  // subscribe to multiple categories
+  ;['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(
+    (category) => log.on(category, writeLog)
+  )
+
+  // subscribe to an event
+  log.on('app_startup', writeLog)
+
+  // subscribe to all events
+  log.on('*', writeLog)
+
+  // subscribe to events that have no subscriptions
+  log.on('no_listeners', writeLog)
+
+  log.emit('app_startup', 'info', { hello: 'world' })
+}
+
+// README - piping emitters
+const emitterPiping = async () => {
+  const log1 = new LogEmitter()
+  const log2 = new LogEmitter()
+  const log3 = new LogEmitter()
+  const logWriter = new writers.DevConsoleWriter({
+    formatter: new formatters.BlockFormatter()
+  })
+  const writeLog = async (meta, ...args) =>
+    logWriter.write(args && args.length === 1 ? args[0] : args, meta)
+
+  log2.on('*', log1.pipe())
+  log3.on('*', log1.pipe())
+  log1.on('info', writeLog)
+
+  log2.emit('log2', 'info', { hello: 'world' })
+  log3.emit('log3', 'info', { hello: 'world' })
+}
+
+// README - child emitters
+const emitterChildren = async () => {
+  const log1 = new LogEmitter()
+  const log2 = log1.child()
+  const log3 = log1.child()
+  const logWriter = new writers.DevConsoleWriter({
+    formatter: new formatters.BlockFormatter()
+  })
+  const writeLog = async (meta, ...args) =>
+    logWriter.write(args && args.length === 1 ? args[0] : args, meta)
+
+  log1.on('info', writeLog)
+
+  log2.emit('log2', 'info', { hello: 'world' })
+  log3.emit('log3', 'info', { hello: 'world' })
+}
+
+// README - adding context to emitters
+const emitterContext = async () => {
+  const Koa = require('koa')
+  const Router = require('koa-router')
+
+  const appLogger = new LogEmitter()
+  appLogger.on('*', console.log)
+
+  const app = new Koa()
+  const router = new Router()
+
+  router.get('/', async (ctx) => {
+    ctx.state.log.emit('http_get', 'info', { hello: 'world' })
+    ctx.status = 200
+    ctx.body = { hello: 'world' }
+  })
+
+  app.use(async (ctx, next) => {
+    ctx.state = ctx.state || {}
+    ctx.state.log = appLogger.child({
+      context: {
+        method: ctx.request.method,
+        href: ctx.request.href,
+      },
+    })
+
+    await next()
+  })
+
+  app.use(router.routes())
+  app.listen(3000)
+  appLogger.emit('startup', 'info', 'listening on port 3000')
+}
+
+// README - roll your own log writer
+const rollYourLogWriter = async () => {
+  const log = new LogEmitter({
+    context: {
+      a: 'property'
+    }
+  })
+
+  log.on('*', async (meta, ...args) => {
+    const parts = [
+      `[${new Date(meta.time).toISOString()}]`,
+      `${meta.category.toUpperCase().padStart(6)}`,
+      `(${meta.event.toUpperCase()})`.padStart(12) + ':',
+      `${meta.pid} on ${meta.hostname}`,
+      `(${meta.source}):`,
+    ]
+    const body = typeof args[0] === 'string'
+      ? { ...meta.context, ...{ msg: args[0] } }
+      : { ...meta.context, ...args[0] }
+
+    delete body.secret
+    console.log(parts.join(' ') + JSON.stringify(body))
+  })
+
+  log.emit('startup', 'info', 'listening on port 3000')
+  log.emit('has_secret', 'debug', { hello: 'world', secret: 'shhhhh' })
+}
+
+;(async () => {
+  await standardFare()
+  await multipleParams()
+  await publishAndEmit()
+  await countsAndGaugesLogger()
+  await countsAndGaugesLogEmitter()
+  await latencyLogger()
+  await latencyLogEmitter()
+  await logEmitter()
+  await gettingStarted()
+  await emitterPiping()
+  await emitterChildren()
+  // await emitterContext()
+  await rollYourLogWriter()
 })()


### PR DESCRIPTION
Using NodeJS' events package makes this library a much lighter lift. The
LogEmitter extends NodeJS' events package with features I found wanting
using pubsub for logging, and by looking at Pino, and Bunyan.