### PR TITLE
feat: adds try-with-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ const log = new LogEmitter({
   latencyTimeoutMs: 30000,
   METRICS_CATEGORIES: {
     WARN: {
-      CATEGORY: 'metrics_warn',
+      CATEGORY: 'metrics_warn', // default is 'warn'
       HELP: 'my override'
     },
     // COUNT: // same schema as WARN example
@@ -242,11 +242,13 @@ log.on('latency_start', stubHandler)
 log.on('latency_end', stubHandler)
 
 // measures the length of time it takes to complete a given action
+// you can just subscribe to this, if you want the duration, and
+// don't need to set a timer yourself
 log.on('latency', stubHandler)
 
 // for events where this module encounters unexpected behavior
 // i.e. latency timeouts
-log.on('warn', stubHandler)
+log.on('metrics_warn' /* 'warn' if you didn't override this */ , stubHandler)
 
 await log.tryWithMetrics({
   name: 'http_request',

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,11 @@ export interface ILoggerOptions {
   pid?: number;
 }
 
+interface CATEGORY_SCHEMA {
+  CATEGORY: string;
+  HELP: string;
+}
+
 export interface ILogEmitterOptions {
   source?: string;
   hostname?: string;
@@ -50,6 +55,25 @@ export interface ILogEmitterOptions {
   wildcardEvent?: string;
   noListenersEvent?: string;
   context?: any;
+  // for try with metrics:
+  latencyTimeoutMs?: number;
+  METRICS_CATEGORIES?: {
+    WARN?: CATEGORY_SCHEMA,
+    COUNT?: CATEGORY_SCHEMA,
+    COUNT_ERRORS?: CATEGORY_SCHEMA,
+    GAUGE?: CATEGORY_SCHEMA,
+    GAUGE_INCREASE?: CATEGORY_SCHEMA,
+    GAUGE_DECREASE?: CATEGORY_SCHEMA,
+    LATENCY_START?: CATEGORY_SCHEMA,
+    LATENCY_END?: CATEGORY_SCHEMA,
+    LATENCY?: CATEGORY_SCHEMA,
+  },
+}
+
+export interface ITryWithMetricsOptions {
+  name: string;
+  labels?: any; // i.e. { method: ctx.request.method, href: ctx.request.href }
+  shouldCountError? (err: Error, input: ITryWithMetricsOptions): boolean;
 }
 
 /**
@@ -135,4 +159,5 @@ declare class LogEmitter extends EventEmitter {
   emit(event: string | symbol, level: string, ...args: any[]): boolean;
   pipe(meta: ILogEmitterMeta, ...args: any[]): boolean;
   child(options: ILogEmitterOptions): LogEmitter;
+  tryWithMetrics(options: ITryWithMetricsOptions): (action: Promise<any>) => Promise<any>;
 }

--- a/index.js
+++ b/index.js
@@ -36,6 +36,16 @@ const writers = {
   StdoutWriter,
 }
 
+// middleware / utils
+const { makeId } = require('./src/make-id')()
+const time = require('./src/time')()
+const { makeTryWithMetrics, METRICS_CATEGORIES } = require('./src/try-with-metrics')({
+  blueprint,
+  immutable,
+  makeId,
+  time,
+})
+
 // logger
 const { LogMetaFactory } = require('./src/LogMetaFactory')({ blueprint, immutable, os })
 const { Logger } = require('./src/Logger')({
@@ -50,6 +60,13 @@ const { LogEmitter } = require('./src/LogEmitter')({
   immutable,
   EventEmitter,
   LogMetaFactory,
+  makeTryWithMetrics,
 })
 
-module.exports = { Logger, formatters, writers, LogEmitter }
+module.exports = {
+  Logger,
+  formatters,
+  writers,
+  LogEmitter,
+  METRICS_CATEGORIES,
+}

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,8 @@
 module.exports = (test, dependencies) => {
   'use strict'
 
-  const { LogEmitter } = dependencies
+  const { LogEmitter, METRICS_CATEGORIES } = dependencies
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
   return test('given @polyn/logger', {
     'given LogEmitter': {
@@ -115,6 +116,134 @@ module.exports = (test, dependencies) => {
           expect(actual.noSubscriberResults[0][0].time).to.be.a('number')
         },
       },
-    }
+    },
+    'given try-with-metrics': {
+      given: () => ({ emitter: new LogEmitter() }),
+      'when an action succeeds': {
+        when: async ({ emitter }) => {
+          const results = []
+          const categories = []
+          const sleepTime = 5
+          const expected = {
+            name: 'io',
+            labels: { a: 'label' },
+          }
+
+          emitter.on('*', (meta, ...args) => {
+            results.push({ meta, log: args[0] })
+            categories.push(meta.category)
+          })
+          await emitter.tryWithMetrics(expected)(async () => {
+            await sleep(sleepTime)
+          })
+
+          return { results, categories, sleepTime, expected }
+        },
+        'it should emit metrics events': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          const expectCount = (category, count) => {
+            const len = actual.categories.filter((a) => a === category).length
+            expect(len, `should emit ${count} ${category}`).to.equal(count)
+          }
+
+          expectCount(METRICS_CATEGORIES.COUNT.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.GAUGE.CATEGORY, 2)
+          expectCount(METRICS_CATEGORIES.GAUGE_INCREASE.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.GAUGE_DECREASE.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.LATENCY_START.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.LATENCY_END.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.LATENCY.CATEGORY, 1)
+        },
+        'the logs should meet the metrics schema': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          actual.results.forEach((r) => {
+            expect(r.meta.event).to.equal(actual.expected.name)
+            expect(typeof r.log.id === 'string', 'id').to.equal(true)
+            expect(typeof r.log.help === 'string', 'help').to.equal(true)
+            expect(r.log.labels).to.deep.equal(actual.expected.labels)
+          })
+        },
+        'it should emit latency with duration metrics': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          const found = actual.results.find((r) => r.meta.category === METRICS_CATEGORIES.LATENCY.CATEGORY)
+          expect(typeof found === 'undefined', 'should emit latency category').to.equal(false)
+          expect(found.log.duration.milliseconds).to.be.greaterThan(actual.sleepTime)
+        }
+      },
+      'when an action exceeds the timeout': {
+        given: () => ({ emitter: new LogEmitter({ latencyTimeoutMs: 5 }) }),
+        when: async ({ emitter }) => {
+          const results = []
+          const sleepTime = 10
+
+          emitter.on('*', (meta, ...args) => {
+            results.push({ meta, log: args[0] })
+          })
+          await emitter.tryWithMetrics({
+            name: 'io',
+            labels: { a: 'label' },
+          })(async () => {
+            await sleep(sleepTime)
+          })
+
+          return { results, sleepTime }
+        },
+        'it should emit a warn category': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          const found = actual.results.find((r) => r.meta.category === METRICS_CATEGORIES.WARN.CATEGORY)
+          expect(typeof found === 'undefined', 'should emit warn').to.equal(false)
+          expect(found.log.message).to.equal('action_timed_out')
+          expect(found.log.originalLog).to.be.a('object')
+        }
+      },
+      'when an action throws': {
+        when: async ({ emitter }) => {
+          const events = []
+          const categories = []
+          let err = null
+
+          emitter.on('*', (meta, ...args) => {
+            events.push({ meta, log: args[0] })
+            categories.push(meta.category)
+          })
+
+          try {
+            await emitter.tryWithMetrics({
+              name: 'io',
+              labels: { a: 'label' },
+            })(async () => {
+              throw new Error('BOOM!')
+            })
+          } catch (e) {
+            err = e
+          }
+
+          return { events, categories, err }
+        },
+        'it should throw': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          expect(actual.err).to.not.equal(null)
+          expect(actual.err.message).to.equal('BOOM!')
+        },
+        'it should emit a COUNT_ERRORS category, as well as emitting all the other metrics events, except for LATENCY': (expect) => (err, actual) => {
+          expect(err).to.equal(null)
+          const expectCount = (category, count) => {
+            const len = actual.categories.filter((a) => a === category).length
+            expect(len, `should emit ${count} ${category}`).to.equal(count)
+          }
+
+          expectCount(METRICS_CATEGORIES.COUNT_ERRORS.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.COUNT.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.GAUGE.CATEGORY, 2)
+          expectCount(METRICS_CATEGORIES.GAUGE_INCREASE.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.GAUGE_DECREASE.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.LATENCY_START.CATEGORY, 1)
+          expectCount(METRICS_CATEGORIES.LATENCY_END.CATEGORY, 1)
+
+          // should not emit latency of failed actions
+          expectCount(METRICS_CATEGORIES.LATENCY.CATEGORY, 0)
+        },
+      },
+    },
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polyn/logger",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An async, event based logger for NodeJS",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/LogEmitter.js
+++ b/src/LogEmitter.js
@@ -3,13 +3,14 @@
  * @param {@polyn/immutable} immutable
  * @param {LogMetaFactory} LogMetaFactory
  * @param {events} EventEmitter
+ * @param {Function} makeTryWithMetrics
  */
 function LogEmitterFactory (deps) {
   'use strict'
 
   const { optional } = deps.blueprint
   const { immutable } = deps.immutable
-  const { LogMetaFactory, EventEmitter } = deps
+  const { LogMetaFactory, EventEmitter, makeTryWithMetrics } = deps
   const TAB_AT_EXP = /^(\s+)at /
 
   const LogEmitterOptions = immutable('LogEmitterOptions', {
@@ -28,6 +29,10 @@ function LogEmitterFactory (deps) {
       this.LogMeta = LogMetaFactory({
         ...{ isValidEvent: () => true },
         ...this.options,
+      })
+      this.tryWithMetrics = makeTryWithMetrics({
+        ...input,
+        ...{ emitter: this },
       })
     }
 

--- a/src/make-id.js
+++ b/src/make-id.js
@@ -1,0 +1,33 @@
+function MakeIdFactory () {
+  'use strict'
+
+  const ALPHA_NUM = 'abcdefghijklmnopqrstuvwxyz0123456789'
+  const templates = {}
+
+  const makeTemplate = (length = 8) => {
+    if (!templates[`l${length}`]) {
+      if (length < 1) {
+        throw new Error('Invalid id length: expected length to be a number greater than 0')
+      }
+
+      templates[`l${length}`] = new Array(length + 1).join('x')
+    }
+
+    return templates[`l${length}`]
+  }
+
+  const _rand = (min, max) => () => (Math.random() * (max - min + 1)) << 0
+  const rand = _rand(0, ALPHA_NUM.length - 1)
+
+  /**
+   * Makes a random hex string of a given length
+   * @param length {number?} - the length of the random string
+   * @returns {string} - a random string (i.e. "4e42a851")
+   */
+  const makeId = (length) => makeTemplate(length)
+    .replace(/x/g, () => ALPHA_NUM[rand()])
+
+  return { makeId }
+}
+
+module.exports = MakeIdFactory

--- a/src/time.js
+++ b/src/time.js
@@ -1,0 +1,129 @@
+function TimeFactory () {
+  'use strict'
+
+  const UNITS = {
+    SECONDS: 's',
+    MILLISECONDS: 'ms',
+    MICROSECONDS: 'us',
+    NANOSECONDS: 'ns'
+  }
+  const UNITS_ARRAY = Object.keys(UNITS).map((key) => UNITS[key])
+  const isValidUnit = (unit) => UNITS_ARRAY.includes(unit)
+
+  const makeClock = (MULTIPLIERS, makeTime) => {
+    const clock = function (option) {
+      switch (option) {
+        case 's':
+          return makeTime(MULTIPLIERS.SECONDS)
+        case 'ms':
+          return makeTime(MULTIPLIERS.MILLISECONDS)
+        case 'us':
+          return makeTime(MULTIPLIERS.MICROSECONDS)
+        case 'ns':
+          return makeTime(MULTIPLIERS.NANOSECONDS)
+        default:
+          return {
+            seconds: makeTime(MULTIPLIERS.SECONDS),
+            milliseconds: makeTime(MULTIPLIERS.MILLISECONDS),
+            microseconds: makeTime(MULTIPLIERS.MICROSECONDS),
+            nanoseconds: makeTime(MULTIPLIERS.NANOSECONDS)
+          }
+      }
+    }
+
+    clock.seconds = () => clock(UNITS.SECONDS)
+    clock.milliseconds = () => clock(UNITS.MILLISECONDS)
+    clock.microseconds = () => clock(UNITS.MICROSECONDS)
+    clock.nanoseconds = () => clock(UNITS.NANOSECONDS)
+
+    return clock
+  }
+
+  const CONVERSIONS = {
+    s: {
+      SECONDS: 1,
+      MILLISECONDS: 1000,
+      MICROSECONDS: 1000000,
+      NANOSECONDS: 1000000000
+    },
+    ms: {
+      SECONDS: 0.001,
+      MILLISECONDS: 1,
+      MICROSECONDS: 1000,
+      NANOSECONDS: 1000000
+    },
+    us: {
+      SECONDS: 0.000001,
+      MILLISECONDS: 0.001,
+      MICROSECONDS: 1,
+      NANOSECONDS: 1000
+    },
+    ns: {
+      SECONDS: 1e9,
+      MILLISECONDS: 0.000001,
+      MICROSECONDS: 0.001,
+      NANOSECONDS: 1
+    }
+  }
+
+  const duration = (start, end, timeUnits) => {
+    const conversions = CONVERSIONS[timeUnits]
+
+    return {
+      seconds: (end - start) * conversions.SECONDS,
+      milliseconds: (end - start) * conversions.MILLISECONDS,
+      microseconds: (end - start) * conversions.MICROSECONDS,
+      nanoseconds: (end - start) * conversions.NANOSECONDS
+    }
+  }
+
+  const addDurations = (...durations) => {
+    const duration = {
+      seconds: 0,
+      milliseconds: 0,
+      microseconds: 0,
+      nanoseconds: 0
+    }
+
+    durations.forEach((_dur) => {
+      if (typeof _dur.microseconds === 'number' && _dur.microseconds > 0) {
+        duration.seconds += _dur.seconds
+        duration.milliseconds += _dur.milliseconds
+        duration.microseconds += _dur.microseconds
+        duration.nanoseconds += _dur.nanoseconds
+      }
+    })
+
+    return duration
+  }
+
+  const NODE_MULTIPLIERS = {
+    SECONDS: [1, 1e-9],
+    MILLISECONDS: [1e3, 1e-6],
+    MICROSECONDS: [1e6, 1e-3],
+    NANOSECONDS: [1e9, 1]
+  }
+  const BROWSER_MULTIPLIERS = {
+    SECONDS: 0.001,
+    MILLISECONDS: 1,
+    MICROSECONDS: 1000,
+    NANOSECONDS: 1000000
+  }
+
+  const nodeClock = (multipliers, hrtime) => {
+    const time = Array.isArray(hrtime) ? process.hrtime(hrtime) : process.hrtime()
+    return (time[0] * multipliers[0]) + (time[1] * multipliers[1])
+  }
+
+  const browserClock = (multiplier, hrtime) => {
+    return window.performance.now() * multiplier
+  }
+
+  const clock = typeof process !== 'undefined' && typeof process.hrtime === 'function'
+    ? makeClock(NODE_MULTIPLIERS, nodeClock)
+    : makeClock(BROWSER_MULTIPLIERS, browserClock)
+
+  return { clock, isValidUnit, duration, addDurations }
+}
+
+module.exports = TimeFactory

--- a/src/try-with-metrics.js
+++ b/src/try-with-metrics.js
@@ -1,0 +1,176 @@
+/**
+ * @param {@polyn/blueprint} blueprint
+ * @param {@polyn/immutable} immutable
+ * @param {Function} makeId
+ * @param {Function} clock
+ * @param {Function} duration
+ */
+function TryWithMetricsFactory (deps) {
+  'use strict'
+
+  const { optional } = deps.blueprint
+  const { immutable } = deps.immutable
+  const { makeId, time } = deps
+
+  const _METRICS_CATEGORIES = {
+    WARN: {
+      CATEGORY: 'warn',
+      HELP: 'for events where this module encounters unexpected behavior',
+    },
+    COUNT: {
+      CATEGORY: 'count',
+      HELP: 'counts the number of occurences of a given action',
+    },
+    COUNT_ERRORS: {
+      CATEGORY: 'count_errors',
+      HELP: 'counts the number of errors that occur when executing a given action',
+    },
+    GAUGE: {
+      CATEGORY: 'gauge',
+      HELP: 'tracks the number of a given action currently being executed',
+    },
+    GAUGE_INCREASE: {
+      CATEGORY: 'gauge_increase',
+      HELP: 'tracks an increase in the number of a given action currently beint executed',
+    },
+    GAUGE_DECREASE: {
+      CATEGORY: 'gauge_decrease',
+      HELP: 'tracks an decrease in the number of a given action currently beint executed',
+    },
+    LATENCY_START: {
+      CATEGORY: 'latency_start',
+      HELP: 'tracks the beginning time of a given action',
+    },
+    LATENCY_END: {
+      CATEGORY: 'latency_end',
+      HELP: 'tracks the end time of a given action, and emits the latency event',
+    },
+    LATENCY: {
+      CATEGORY: 'latency',
+      HELP: 'measures the length of time it takes to complete a given action',
+    },
+  }
+
+  const _CATEGORY_SCHEMA = {
+    CATEGORY: 'string',
+    HELP: 'string',
+  }
+
+  const TryWithMetricsOptions = immutable('TryWithMetricsOptions', {
+    emitter: { on: 'function', emit: 'function' },
+    timeUnits: optional(/^(s|ms|us|ns)$/).withDefault('us'),
+    latencyTimeoutMs: optional('number').withDefault(30000),
+    METRICS_CATEGORIES: {
+      WARN: _CATEGORY_SCHEMA,
+      COUNT: _CATEGORY_SCHEMA,
+      COUNT_ERRORS: _CATEGORY_SCHEMA,
+      GAUGE: _CATEGORY_SCHEMA,
+      GAUGE_INCREASE: _CATEGORY_SCHEMA,
+      GAUGE_DECREASE: _CATEGORY_SCHEMA,
+      LATENCY_START: _CATEGORY_SCHEMA,
+      LATENCY_END: _CATEGORY_SCHEMA,
+      LATENCY: _CATEGORY_SCHEMA,
+    },
+  })
+
+  const TryWithMetricsActionOptions = immutable('TryWithMetricsActionOptions', {
+    name: 'string',
+    labels: 'object?',
+    shouldCountError: optional('function').withDefault(() => () => true),
+  })
+
+  const measureLatency = (input) => {
+    const { emitter, METRICS_CATEGORIES, timeUnits, latencyTimeoutMs } = input
+    const latencies = {}
+    const timers = {}
+
+    const addTimeout = (meta, log) => {
+      timers[log.id] = {
+        timeout: setTimeout(() => {
+          emitter.emit(meta.event, METRICS_CATEGORIES.WARN.CATEGORY, {
+            message: 'action_timed_out',
+            originalLog: { log, meta }
+          })
+          removeTimeout(meta, log)
+        }, latencyTimeoutMs)
+      }
+    }
+
+    const removeTimeout = (meta, log) => {
+      const timer = timers[log.id]
+
+      if (timer) {
+        clearTimeout(timer.timeout)
+        delete timers[log.id]
+      }
+    }
+
+    emitter.on(METRICS_CATEGORIES.LATENCY_START.CATEGORY, (meta, ...args) => {
+      const log = args[0]
+      latencies[log.id] = { log, meta, startTime: time.clock(timeUnits) }
+      addTimeout(meta, log)
+    })
+
+    emitter.on(METRICS_CATEGORIES.LATENCY_END.CATEGORY, (meta, ...args) => {
+      const log = args[0]
+      removeTimeout(meta, log)
+      const found = latencies[log.id]
+      const duration = time.duration(found.startTime, time.clock(timeUnits), timeUnits)
+
+      if (!log.err) {
+        // don't measure the duration of failed actions
+        emitter.emit(meta.event, METRICS_CATEGORIES.LATENCY.CATEGORY, {
+          ...log,
+          ...{
+            duration,
+            help: METRICS_CATEGORIES.LATENCY.HELP,
+          }
+        })
+      }
+    })
+  }
+
+  const makeTryWithMetrics = (options) => {
+    const { timeUnits, latencyTimeoutMs, METRICS_CATEGORIES } = new TryWithMetricsOptions({
+      ...{ METRICS_CATEGORIES: _METRICS_CATEGORIES },
+      ...options
+    })
+    const emitter = options.emitter // use the original emitter, not the immutable'd one
+    measureLatency({ emitter, METRICS_CATEGORIES, timeUnits, latencyTimeoutMs })
+
+    return (input) => async (action) => {
+      const {
+        name, labels, shouldCountError,
+      } = new TryWithMetricsActionOptions(input)
+      const id = makeId()
+      let result
+      let err
+
+      try {
+        emitter.emit(name, METRICS_CATEGORIES.COUNT.CATEGORY, { id, labels, help: METRICS_CATEGORIES.COUNT.HELP })
+        emitter.emit(name, METRICS_CATEGORIES.GAUGE.CATEGORY, { id, labels, help: METRICS_CATEGORIES.GAUGE.HELP, direction: 'increase' })
+        emitter.emit(name, METRICS_CATEGORIES.GAUGE_INCREASE.CATEGORY, { id, labels, help: METRICS_CATEGORIES.GAUGE_INCREASE.HELP })
+        emitter.emit(name, METRICS_CATEGORIES.LATENCY_START.CATEGORY, { id, labels, help: METRICS_CATEGORIES.LATENCY_START.HELP })
+
+        result = await action()
+      } catch (error) {
+        err = error
+        if (shouldCountError(error, input)) {
+          emitter.emit(name, METRICS_CATEGORIES.COUNT_ERRORS.CATEGORY, { id, labels, help: METRICS_CATEGORIES.COUNT_ERRORS.HELP })
+        }
+
+        throw error
+      } finally {
+        emitter.emit(name, METRICS_CATEGORIES.LATENCY_END.CATEGORY, { id, labels, help: METRICS_CATEGORIES.LATENCY_END.HELP, err })
+        emitter.emit(name, METRICS_CATEGORIES.GAUGE.CATEGORY, { id, labels, help: METRICS_CATEGORIES.GAUGE.HELP, direction: 'decrease' })
+        emitter.emit(name, METRICS_CATEGORIES.GAUGE_DECREASE.CATEGORY, { id, labels, help: METRICS_CATEGORIES.GAUGE_DECREASE.HELP })
+      }
+
+      return result
+    }
+  }
+
+  return { makeTryWithMetrics, METRICS_CATEGORIES: _METRICS_CATEGORIES }
+}
+
+module.exports = TryWithMetricsFactory

--- a/test.js
+++ b/test.js
@@ -1,15 +1,10 @@
 const { expect } = require('chai')
 const supposed = require('supposed')
-const { Logger, LogEmitter, formatters, writers } = require('@polyn/logger')
+const polynLogger = require('@polyn/logger')
 
 module.exports = supposed.Suite({
   name: 'polyn-logger',
   assertionLibrary: expect,
-  inject: {
-    Logger,
-    LogEmitter,
-    formatters,
-    writers,
-  },
+  inject: polynLogger,
 }).runner()
   .run()


### PR DESCRIPTION
We often need to track the performance (latency) of I/O bound
features (i.e. HTTP requests, database requests, API response
times), as well as compute bound features (i.e. algorithms).
Knowing the number of times a feature is used (counts), as well
as the volume it receives (gauges) can help us understand which
features are most important to our users, or if a feature is
actively being used, right now.

This adds `tryWithMetrics` to the LogEmitter, to simplify gathering
these kinds of metrics, so all you need to do is supply the writer to
get these metrics into your tracking system.