### PR TITLE
fix: updates typedefs

### DIFF
--- a/examples-typescript.ts
+++ b/examples-typescript.ts
@@ -1,4 +1,4 @@
-import { Logger, ILogWriter, formatters, writers } from '.';
+import { Logger, LogEmitter, ILogWriter, formatters, writers, ILogMeta } from '.';
 
 const {
   BlockFormatter,
@@ -16,10 +16,23 @@ const {
 } = writers
 
 const events = ['local2', 'local', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']
-const logger = new Logger({ events })
-let log = logger.withSource(__filename).log
-
 const arrayWriter = new ArrayWriter({ formatter: new StringFormatter() })
+
+const customWriter = function () {
+  const write = async (log: any, meta: ILogMeta) => {
+    // format the log
+
+    // write the log
+    console.log('CUSTOM:', log, meta)
+  }
+
+  const listen = (meta: ILogMeta, ...args: any) => write(
+    args && args.length === 1 ? args[0] : args, meta,
+  )
+
+  return { write, listen }
+}
+
 const _writers: ILogWriter[] = [
   /* 0 */ new DevConsoleWriter({ formatter: new BlockFormatter() }),
   /* 1 */ new DevConsoleWriter({ formatter: new BlockFormatter({ useColors: false }) }),
@@ -28,17 +41,14 @@ const _writers: ILogWriter[] = [
   /* 4 */ new StdoutWriter({ formatter: new JsonFormatter() }),
   /* 5 */ new StdoutWriter({ formatter: new BunyanFormatter(events) }),
   /* 6 */ arrayWriter,
-  /* 7 */ { // custom writer
-    write: async (log, meta) => {
-      // format the log
-
-      // write the log
-      console.log('CUSTOM:', log, meta)
-    }
-  }
+  /* 7 */ customWriter()
 ]
 
 ;(async () => {
+  // 0.2.2 and previous
+  const logger = new Logger({ events })
+  let log = logger.withSource(__filename).log
+
   await logger.subscribe(events, _writers[0])
 
   // setTimeout(() => { console.log(arrayWriter.history) }, 100)
@@ -61,4 +71,33 @@ const _writers: ILogWriter[] = [
   log.warn({ hello: 'warn' })
   log.error({ hello: 'error' })
   log.fatal({ hello: 'fatal' })
+})()
+
+;(() => {
+  // 0.3 and after
+  const logger = new LogEmitter()
+
+  events.forEach((event: string) => {
+    logger.on(event, _writers[7].listen)
+  })
+
+  logger.emit('testing_typescript', 'local', { hello: 'local' })
+  logger.emit('testing_typescript', 'local2', { hello: 'local2' })
+  logger.emit('testing_typescript', 'trace', { hello: 'trace' })
+  logger.emit('testing_typescript', 'debug', { hello: 'debug' })
+  logger.emit('testing_typescript', 'info', { hello: 'info' })
+  logger.emit('testing_typescript', 'warn', { hello: 'warn' })
+  logger.emit('testing_typescript', 'error', { hello: 'error' })
+  logger.emit('testing_typescript', 'fatal', { hello: 'fatal' })
+
+  const child = logger.child({ context: { child: true, foo: 'bar' } })
+
+  child.emit('testing_typescript', 'local', { hello: 'local' })
+  child.emit('testing_typescript', 'local2', { hello: 'local2' })
+  child.emit('testing_typescript', 'trace', { hello: 'trace' })
+  child.emit('testing_typescript', 'debug', { hello: 'debug' })
+  child.emit('testing_typescript', 'info', { hello: 'info' })
+  child.emit('testing_typescript', 'warn', { hello: 'warn' })
+  child.emit('testing_typescript', 'error', { hello: 'error' })
+  child.emit('testing_typescript', 'fatal', { hello: 'fatal' })
 })()

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export interface ILogFormatter {
 
 export interface ILogWriter {
   write (log: any, meta: ILogMeta): Promise<void>;
+  listen (meta: ILogMeta, ...args: any): Promise<void>;
 }
 
 export interface ILoggerOptions {
@@ -139,23 +140,51 @@ declare namespace writers {
       maxSize?: number;
     });
     write (log: any, meta: ILogMeta): Promise<void>;
+    listen (meta: ILogMeta, ...args: any): Promise<void>;
   }
   export class ConsoleWriter implements ILogWriter {
     constructor(options: { formatter: ILogFormatter });
     write (log: any, meta: ILogMeta): Promise<void>;
+    listen (meta: ILogMeta, ...args: any): Promise<void>;
   }
   export class DevConsoleWriter implements ILogWriter {
     constructor(options: { formatter: ILogFormatter });
     write (log: any, meta: ILogMeta): Promise<void>;
+    listen (meta: ILogMeta, ...args: any): Promise<void>;
   }
   export class StdoutWriter implements ILogWriter {
     constructor(options: { formatter: ILogFormatter });
     write (log: any, meta: ILogMeta): Promise<void>;
+    listen (meta: ILogMeta, ...args: any): Promise<void>;
   }
 }
 
-declare class LogEmitter extends EventEmitter {
-  constructor(options: ILogEmitterOptions | any);
+export interface ILogEmitter extends EventEmitter {
+  emit(event: string | symbol, level: string, ...args: any[]): boolean;
+  pipe(meta: ILogEmitterMeta, ...args: any[]): boolean;
+  child(options: ILogEmitterOptions): LogEmitter;
+  tryWithMetrics(options: ITryWithMetricsOptions): (action: Promise<any>) => Promise<any>;
+}
+
+/**
+ * This is a copy of NodeJS' interface which they didn't export
+ * for some reason. Using a copy risks falling out of sync with NodeJS
+ * so the constructor for LogEmitter accepts `options?: ILogEmitterOptions | any | undefined`
+ * instead of `options?: ILogEmitterOptions | EventEmitterOptions | undefined`.
+ *
+ * This copy is here for posterity... so you can see an example of the
+ * base class options that you could pass through with your options
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/events.d.ts
+ */
+interface EventEmitterOptions {
+  /**
+   * Enables automatic capturing of promise rejection.
+   */
+  captureRejections?: boolean | undefined;
+}
+
+declare class LogEmitter extends EventEmitter implements ILogEmitter {
+  constructor(options?: ILogEmitterOptions | any | undefined);
   emit(event: string | symbol, level: string, ...args: any[]): boolean;
   pipe(meta: ILogEmitterMeta, ...args: any[]): boolean;
   child(options: ILogEmitterOptions): LogEmitter;

--- a/src/try-with-metrics.test.js
+++ b/src/try-with-metrics.test.js
@@ -10,7 +10,7 @@ module.exports = (test, dependencies) => {
       when: async ({ emitter }) => {
         const results = []
         const categories = []
-        const sleepTime = 5
+        const sleepTime = 6
         const expected = {
           name: 'io',
           labels: { a: 'label' },
@@ -54,7 +54,7 @@ module.exports = (test, dependencies) => {
         expect(err).to.equal(null)
         const found = actual.results.find((r) => r.meta.category === METRICS_CATEGORIES.LATENCY.CATEGORY)
         expect(typeof found === 'undefined', 'should emit latency category').to.equal(false)
-        expect(found.log.duration.milliseconds).to.be.greaterThan(actual.sleepTime)
+        expect(found.log.duration.milliseconds).to.be.greaterThan(actual.sleepTime - 1) // sleep time is approximate, so subtract one in case it runs sooner than expected
       },
     },
     'when an action exceeds the timeout': {


### PR DESCRIPTION
The index.d.ts file was missing the `listen` function for ILogWriter and the LogEmitter class typedef wasn't carrying through the EventEmitter properties for some reason. This updates those typedefs and also adds new TypeScript tests to validate the changes.